### PR TITLE
feat: migrate UDM enum to reference tables #106

### DIFF
--- a/examples/infra-assurance/ia-example.omc.sqla.fixture.puml
+++ b/examples/infra-assurance/ia-example.omc.sqla.fixture.puml
@@ -10,6 +10,62 @@
     FontSize 12
   }
 
+  entity "party_role" as party_role {
+      **party_role_id**: INTEGER
+    --
+    * code: TEXT
+    * value: TEXT
+      created_at: TIMESTAMP
+      created_by: TEXT
+      updated_at: TIMESTAMP
+      updated_by: TEXT
+      deleted_at: TIMESTAMP
+      deleted_by: TEXT
+      activity_log: TEXT
+  }
+
+  entity "party_identifier_type" as party_identifier_type {
+      **party_identifier_type_id**: INTEGER
+    --
+    * code: TEXT
+    * value: TEXT
+      created_at: TIMESTAMP
+      created_by: TEXT
+      updated_at: TIMESTAMP
+      updated_by: TEXT
+      deleted_at: TIMESTAMP
+      deleted_by: TEXT
+      activity_log: TEXT
+  }
+
+  entity "person_type" as person_type {
+      **person_type_id**: INTEGER
+    --
+    * code: TEXT
+    * value: TEXT
+      created_at: TIMESTAMP
+      created_by: TEXT
+      updated_at: TIMESTAMP
+      updated_by: TEXT
+      deleted_at: TIMESTAMP
+      deleted_by: TEXT
+      activity_log: TEXT
+  }
+
+  entity "contact_type" as contact_type {
+      **contact_type_id**: INTEGER
+    --
+    * code: TEXT
+    * value: TEXT
+      created_at: TIMESTAMP
+      created_by: TEXT
+      updated_at: TIMESTAMP
+      updated_by: TEXT
+      deleted_at: TIMESTAMP
+      deleted_by: TEXT
+      activity_log: TEXT
+  }
+
   entity "organization_role_type" as organization_role_type {
       **organization_role_type_id**: INTEGER
     --
@@ -145,7 +201,7 @@
       **party_identifier_id**: INTEGER
     --
     * identifier_number: TEXT
-    * party_identifier_type_id: TEXT
+    * party_identifier_type_id: INTEGER
     * party_id: INTEGER
       created_at: TIMESTAMP
       created_by: TEXT
@@ -160,7 +216,7 @@
       **person_id**: INTEGER
     --
     * party_id: INTEGER
-    * person_type_id: TEXT
+    * person_type_id: INTEGER
     * person_first_name: TEXT
     * person_last_name: TEXT
       honorific_prefix: TEXT
@@ -180,7 +236,7 @@
     * party_id: INTEGER
     * related_party_id: INTEGER
     * relation_type_id: TEXT
-      party_role_id: TEXT
+      party_role_id: INTEGER
       created_at: TIMESTAMP
       created_by: TEXT
       updated_at: TIMESTAMP
@@ -224,7 +280,7 @@
   entity "contact_electronic" as contact_electronic {
       **contact_electronic_id**: INTEGER
     --
-    * contact_type_id: TEXT
+    * contact_type_id: INTEGER
     * party_id: INTEGER
     * electronics_details: TEXT
       created_at: TIMESTAMP
@@ -239,7 +295,7 @@
   entity "contact_land" as contact_land {
       **contact_land_id**: INTEGER
     --
-    * contact_type_id: TEXT
+    * contact_type_id: INTEGER
     * party_id: INTEGER
     * address_line1: TEXT
     * address_line2: TEXT
@@ -898,15 +954,20 @@
   graph |o..o{ boundary
   host |o..o{ host_boundary
   boundary |o..o{ raci_matrix_subject_boundary
+  party_identifier_type |o..o{ party_identifier
   party |o..o{ party_identifier
   party |o..o{ person
+  person_type |o..o{ person
   party |o..o{ party_relation
   party |o..o{ party_relation
+  party_role |o..o{ party_relation
   party |o..o{ organization
   person |o..o{ organization_role
   organization |o..o{ organization_role
   organization_role_type |o..o{ organization_role
+  contact_type |o..o{ contact_electronic
   party |o..o{ contact_electronic
+  contact_type |o..o{ contact_land
   party |o..o{ contact_land
   organization |o..o{ asset
   vulnerability_source |o..o{ vulnerability

--- a/examples/infra-assurance/ia-example.omc.sqla.fixture.sh
+++ b/examples/infra-assurance/ia-example.omc.sqla.fixture.sh
@@ -45,11 +45,6 @@ CREATE TABLE IF NOT EXISTS "party_type" (
     "value" TEXT NOT NULL,
     "created_at" TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 );
-CREATE TABLE IF NOT EXISTS "party_role_type" (
-    "code" TEXT PRIMARY KEY NOT NULL,
-    "value" TEXT NOT NULL,
-    "created_at" TIMESTAMP DEFAULT CURRENT_TIMESTAMP
-);
 CREATE TABLE IF NOT EXISTS "contract_status" (
     "code" TEXT PRIMARY KEY NOT NULL,
     "value" TEXT NOT NULL,
@@ -185,21 +180,6 @@ CREATE TABLE IF NOT EXISTS "party_relation_type" (
     "value" TEXT NOT NULL,
     "created_at" TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 );
-CREATE TABLE IF NOT EXISTS "party_identifier_type" (
-    "code" TEXT PRIMARY KEY NOT NULL,
-    "value" TEXT NOT NULL,
-    "created_at" TIMESTAMP DEFAULT CURRENT_TIMESTAMP
-);
-CREATE TABLE IF NOT EXISTS "person_type" (
-    "code" TEXT PRIMARY KEY NOT NULL,
-    "value" TEXT NOT NULL,
-    "created_at" TIMESTAMP DEFAULT CURRENT_TIMESTAMP
-);
-CREATE TABLE IF NOT EXISTS "contact_type" (
-    "code" TEXT PRIMARY KEY NOT NULL,
-    "value" TEXT NOT NULL,
-    "created_at" TIMESTAMP DEFAULT CURRENT_TIMESTAMP
-);
 CREATE TABLE IF NOT EXISTS "training_subject" (
     "code" TEXT PRIMARY KEY NOT NULL,
     "value" TEXT NOT NULL,
@@ -272,6 +252,58 @@ CREATE TABLE IF NOT EXISTS "asset_risk_type" (
 );
 
 -- content tables
+CREATE TABLE IF NOT EXISTS "party_role" (
+    "party_role_id" INTEGER PRIMARY KEY AUTOINCREMENT,
+    "code" TEXT /* UNIQUE COLUMN */ NOT NULL,
+    "value" TEXT NOT NULL,
+    "created_at" TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    "created_by" TEXT DEFAULT 'UNKNOWN',
+    "updated_at" TIMESTAMP,
+    "updated_by" TEXT,
+    "deleted_at" TIMESTAMP,
+    "deleted_by" TEXT,
+    "activity_log" TEXT,
+    UNIQUE("code")
+);
+CREATE TABLE IF NOT EXISTS "party_identifier_type" (
+    "party_identifier_type_id" INTEGER PRIMARY KEY AUTOINCREMENT,
+    "code" TEXT /* UNIQUE COLUMN */ NOT NULL,
+    "value" TEXT NOT NULL,
+    "created_at" TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    "created_by" TEXT DEFAULT 'UNKNOWN',
+    "updated_at" TIMESTAMP,
+    "updated_by" TEXT,
+    "deleted_at" TIMESTAMP,
+    "deleted_by" TEXT,
+    "activity_log" TEXT,
+    UNIQUE("code")
+);
+CREATE TABLE IF NOT EXISTS "person_type" (
+    "person_type_id" INTEGER PRIMARY KEY AUTOINCREMENT,
+    "code" TEXT /* UNIQUE COLUMN */ NOT NULL,
+    "value" TEXT NOT NULL,
+    "created_at" TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    "created_by" TEXT DEFAULT 'UNKNOWN',
+    "updated_at" TIMESTAMP,
+    "updated_by" TEXT,
+    "deleted_at" TIMESTAMP,
+    "deleted_by" TEXT,
+    "activity_log" TEXT,
+    UNIQUE("code")
+);
+CREATE TABLE IF NOT EXISTS "contact_type" (
+    "contact_type_id" INTEGER PRIMARY KEY AUTOINCREMENT,
+    "code" TEXT /* UNIQUE COLUMN */ NOT NULL,
+    "value" TEXT NOT NULL,
+    "created_at" TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    "created_by" TEXT DEFAULT 'UNKNOWN',
+    "updated_at" TIMESTAMP,
+    "updated_by" TEXT,
+    "deleted_at" TIMESTAMP,
+    "deleted_by" TEXT,
+    "activity_log" TEXT,
+    UNIQUE("code")
+);
 CREATE TABLE IF NOT EXISTS "organization_role_type" (
     "organization_role_type_id" INTEGER PRIMARY KEY AUTOINCREMENT,
     "code" TEXT /* UNIQUE COLUMN */ NOT NULL,
@@ -398,7 +430,7 @@ CREATE TABLE IF NOT EXISTS "party" (
 CREATE TABLE IF NOT EXISTS "party_identifier" (
     "party_identifier_id" INTEGER PRIMARY KEY AUTOINCREMENT,
     "identifier_number" TEXT NOT NULL,
-    "party_identifier_type_id" TEXT NOT NULL,
+    "party_identifier_type_id" INTEGER NOT NULL,
     "party_id" INTEGER NOT NULL,
     "created_at" TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     "created_by" TEXT DEFAULT 'UNKNOWN',
@@ -407,13 +439,13 @@ CREATE TABLE IF NOT EXISTS "party_identifier" (
     "deleted_at" TIMESTAMP,
     "deleted_by" TEXT,
     "activity_log" TEXT,
-    FOREIGN KEY("party_identifier_type_id") REFERENCES "party_identifier_type"("code"),
+    FOREIGN KEY("party_identifier_type_id") REFERENCES "party_identifier_type"("party_identifier_type_id"),
     FOREIGN KEY("party_id") REFERENCES "party"("party_id")
 );
 CREATE TABLE IF NOT EXISTS "person" (
     "person_id" INTEGER PRIMARY KEY AUTOINCREMENT,
     "party_id" INTEGER NOT NULL,
-    "person_type_id" TEXT NOT NULL,
+    "person_type_id" INTEGER NOT NULL,
     "person_first_name" TEXT NOT NULL,
     "person_last_name" TEXT NOT NULL,
     "honorific_prefix" TEXT,
@@ -426,14 +458,14 @@ CREATE TABLE IF NOT EXISTS "person" (
     "deleted_by" TEXT,
     "activity_log" TEXT,
     FOREIGN KEY("party_id") REFERENCES "party"("party_id"),
-    FOREIGN KEY("person_type_id") REFERENCES "person_type"("code")
+    FOREIGN KEY("person_type_id") REFERENCES "person_type"("person_type_id")
 );
 CREATE TABLE IF NOT EXISTS "party_relation" (
     "party_relation_id" INTEGER PRIMARY KEY AUTOINCREMENT,
     "party_id" INTEGER NOT NULL,
     "related_party_id" INTEGER NOT NULL,
     "relation_type_id" TEXT NOT NULL,
-    "party_role_id" TEXT,
+    "party_role_id" INTEGER,
     "created_at" TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     "created_by" TEXT DEFAULT 'UNKNOWN',
     "updated_at" TIMESTAMP,
@@ -444,7 +476,7 @@ CREATE TABLE IF NOT EXISTS "party_relation" (
     FOREIGN KEY("party_id") REFERENCES "party"("party_id"),
     FOREIGN KEY("related_party_id") REFERENCES "party"("party_id"),
     FOREIGN KEY("relation_type_id") REFERENCES "party_relation_type"("code"),
-    FOREIGN KEY("party_role_id") REFERENCES "party_role_type"("code")
+    FOREIGN KEY("party_role_id") REFERENCES "party_role"("party_role_id")
 );
 CREATE TABLE IF NOT EXISTS "organization" (
     "organization_id" INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -479,7 +511,7 @@ CREATE TABLE IF NOT EXISTS "organization_role" (
 );
 CREATE TABLE IF NOT EXISTS "contact_electronic" (
     "contact_electronic_id" INTEGER PRIMARY KEY AUTOINCREMENT,
-    "contact_type_id" TEXT NOT NULL,
+    "contact_type_id" INTEGER NOT NULL,
     "party_id" INTEGER NOT NULL,
     "electronics_details" TEXT NOT NULL,
     "created_at" TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
@@ -489,12 +521,12 @@ CREATE TABLE IF NOT EXISTS "contact_electronic" (
     "deleted_at" TIMESTAMP,
     "deleted_by" TEXT,
     "activity_log" TEXT,
-    FOREIGN KEY("contact_type_id") REFERENCES "contact_type"("code"),
+    FOREIGN KEY("contact_type_id") REFERENCES "contact_type"("contact_type_id"),
     FOREIGN KEY("party_id") REFERENCES "party"("party_id")
 );
 CREATE TABLE IF NOT EXISTS "contact_land" (
     "contact_land_id" INTEGER PRIMARY KEY AUTOINCREMENT,
-    "contact_type_id" TEXT NOT NULL,
+    "contact_type_id" INTEGER NOT NULL,
     "party_id" INTEGER NOT NULL,
     "address_line1" TEXT NOT NULL,
     "address_line2" TEXT NOT NULL,
@@ -509,7 +541,7 @@ CREATE TABLE IF NOT EXISTS "contact_land" (
     "deleted_at" TIMESTAMP,
     "deleted_by" TEXT,
     "activity_log" TEXT,
-    FOREIGN KEY("contact_type_id") REFERENCES "contact_type"("code"),
+    FOREIGN KEY("contact_type_id") REFERENCES "contact_type"("contact_type_id"),
     FOREIGN KEY("party_id") REFERENCES "party"("party_id")
 );
 CREATE TABLE IF NOT EXISTS "asset" (
@@ -1363,8 +1395,6 @@ INSERT INTO "execution_context" ("code", "value") VALUES ('SANDBOX', 'sandbox');
 INSERT INTO "execution_context" ("code", "value") VALUES ('EXPERIMENTAL', 'experimental');
 INSERT INTO "party_type" ("code", "value") VALUES ('PERSON', 'Person');
 INSERT INTO "party_type" ("code", "value") VALUES ('ORGANIZATION', 'Organization');
-INSERT INTO "party_role_type" ("code", "value") VALUES ('CUSTOMER', 'Customer');
-INSERT INTO "party_role_type" ("code", "value") VALUES ('VENDOR', 'Vendor');
 INSERT INTO "contract_status" ("code", "value") VALUES ('ACTIVE', 'Active');
 INSERT INTO "contract_status" ("code", "value") VALUES ('AWAITING_APPROVAL', 'Awaiting Approval');
 INSERT INTO "contract_status" ("code", "value") VALUES ('AWAITING_APPROVAL_FOR_RENEWAL', 'Awaiting Approval For Renewal');
@@ -1598,17 +1628,6 @@ INSERT INTO "audit_status" ("code", "value") VALUES ('ACCEPTED', 'Accepted');
 INSERT INTO "party_relation_type" ("code", "value") VALUES ('PERSON_TO_PERSON', 'Person To Person');
 INSERT INTO "party_relation_type" ("code", "value") VALUES ('ORGANIZATION_TO_PERSON', 'Organization To Person');
 INSERT INTO "party_relation_type" ("code", "value") VALUES ('ORGANIZATION_TO_ORGANIZATION', 'Organization To Organization');
-INSERT INTO "party_identifier_type" ("code", "value") VALUES ('UUID', 'UUID');
-INSERT INTO "party_identifier_type" ("code", "value") VALUES ('DRIVING_LICENSE', 'Driving License');
-INSERT INTO "party_identifier_type" ("code", "value") VALUES ('PASSPORT', 'Passport');
-INSERT INTO "person_type" ("code", "value") VALUES ('INDIVIDUAL', 'Individual');
-INSERT INTO "person_type" ("code", "value") VALUES ('PROFESSIONAL', 'Professional');
-INSERT INTO "contact_type" ("code", "value") VALUES ('HOME_ADDRESS', 'Home Address');
-INSERT INTO "contact_type" ("code", "value") VALUES ('OFFICIAL_ADDRESS', 'Official Address');
-INSERT INTO "contact_type" ("code", "value") VALUES ('MOBILE_PHONE_NUMBER', 'Mobile Phone Number');
-INSERT INTO "contact_type" ("code", "value") VALUES ('LAND_PHONE_NUMBER', 'Land Phone Number');
-INSERT INTO "contact_type" ("code", "value") VALUES ('OFFICIAL_EMAIL', 'Official Email');
-INSERT INTO "contact_type" ("code", "value") VALUES ('PERSONAL_EMAIL', 'Personal Email');
 INSERT INTO "training_subject" ("code", "value") VALUES ('HIPAA', 'HIPAA');
 INSERT INTO "training_subject" ("code", "value") VALUES ('CYBER_SECURITY', 'Cyber Security');
 INSERT INTO "training_subject" ("code", "value") VALUES ('OBSERVABILITY_OPEN_TELEMETRY', 'Observability Open Telemetry');
@@ -1705,6 +1724,27 @@ INSERT INTO "incident_status" ("code", "value") VALUES ('SUSPENDED', 'Suspended'
 INSERT INTO "incident_status" ("code", "value") VALUES ('WORK_IN_PROGRESS', 'Work In Progress');
 INSERT INTO "asset_risk_type" ("code", "value") VALUES ('SECURITY', 'Security');
 
+INSERT INTO "party_role" ("code", "value", "created_by", "updated_at", "updated_by", "deleted_at", "deleted_by", "activity_log")
+       VALUES ('CUSTOMER', 'Customer', NULL, NULL, NULL, NULL, NULL, NULL),
+              ('VENDOR', 'Vendor', NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO "party_identifier_type" ("code", "value", "created_by", "updated_at", "updated_by", "deleted_at", "deleted_by", "activity_log")
+       VALUES ('UUID', 'UUID', NULL, NULL, NULL, NULL, NULL, NULL),
+              ('DRIVING_LICENSE', 'Driving License', NULL, NULL, NULL, NULL, NULL, NULL),
+              ('PASSPORT', 'Passport', NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO "person_type" ("code", "value", "created_by", "updated_at", "updated_by", "deleted_at", "deleted_by", "activity_log")
+       VALUES ('INDIVIDUAL', 'Individual', NULL, NULL, NULL, NULL, NULL, NULL),
+              ('PROFESSIONAL', 'Professional', NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO "contact_type" ("code", "value", "created_by", "updated_at", "updated_by", "deleted_at", "deleted_by", "activity_log")
+       VALUES ('HOME_ADDRESS', 'Home Address', NULL, NULL, NULL, NULL, NULL, NULL),
+              ('OFFICIAL_ADDRESS', 'Official Address', NULL, NULL, NULL, NULL, NULL, NULL),
+              ('MOBILE_PHONE_NUMBER', 'Mobile Phone Number', NULL, NULL, NULL, NULL, NULL, NULL),
+              ('LAND_PHONE_NUMBER', 'Land Phone Number', NULL, NULL, NULL, NULL, NULL, NULL),
+              ('OFFICIAL_EMAIL', 'Official Email', NULL, NULL, NULL, NULL, NULL, NULL),
+              ('PERSONAL_EMAIL', 'Personal Email', NULL, NULL, NULL, NULL, NULL, NULL);
+
 INSERT INTO "organization_role_type" ("code", "value", "created_by", "updated_at", "updated_by", "deleted_at", "deleted_by", "activity_log")
        VALUES ('PROJECT_MANAGER_TECHNOLOGY', 'Project Manager Technology', NULL, NULL, NULL, NULL, NULL, NULL),
               ('PROJECT_MANAGER_QUALITY', 'Project Manager Quality', NULL, NULL, NULL, NULL, NULL, NULL),
@@ -1726,42 +1766,41 @@ INSERT INTO "organization_role_type" ("code", "value", "created_by", "updated_at
 ;
 INSERT INTO "party" ("party_type_id", "party_name", "created_by", "updated_at", "updated_by", "deleted_at", "deleted_by", "activity_log") VALUES ('ORGANIZATION', 'Orgnization Name', NULL, NULL, NULL, NULL, NULL, NULL);
 INSERT INTO "organization" ("party_id", "name", "license", "registration_date", "created_by", "updated_at", "updated_by", "deleted_at", "deleted_by", "activity_log") VALUES ((SELECT "party_id" FROM "party" WHERE "party_type_id" = 'ORGANIZATION' AND "party_name" = 'Orgnization Name'), 'Orgnization Name', 'XXXX-XXXXX-XXXX', '2010-01-15', NULL, NULL, NULL, NULL, NULL, NULL);
-INSERT INTO "contact_electronic" ("contact_type_id", "party_id", "electronics_details", "created_by", "updated_at", "updated_by", "deleted_at", "deleted_by", "activity_log") VALUES ('OFFICIAL_EMAIL', (SELECT "party_id" FROM "party" WHERE "party_type_id" = 'ORGANIZATION' AND "party_name" = 'Orgnization Name'), 'orgnization@email.com', NULL, NULL, NULL, NULL, NULL, NULL);
-INSERT INTO "contact_electronic" ("contact_type_id", "party_id", "electronics_details", "created_by", "updated_at", "updated_by", "deleted_at", "deleted_by", "activity_log") VALUES ('LAND_PHONE_NUMBER', (SELECT "party_id" FROM "party" WHERE "party_type_id" = 'ORGANIZATION' AND "party_name" = 'Orgnization Name'), '0523 852 9945', NULL, NULL, NULL, NULL, NULL, NULL);
+INSERT INTO "contact_electronic" ("contact_type_id", "party_id", "electronics_details", "created_by", "updated_at", "updated_by", "deleted_at", "deleted_by", "activity_log") VALUES ((SELECT "contact_type_id" FROM "contact_type" WHERE "code" = 'OFFICIAL_EMAIL'), (SELECT "party_id" FROM "party" WHERE "party_type_id" = 'ORGANIZATION' AND "party_name" = 'Orgnization Name'), 'orgnization@email.com', NULL, NULL, NULL, NULL, NULL, NULL);
+INSERT INTO "contact_electronic" ("contact_type_id", "party_id", "electronics_details", "created_by", "updated_at", "updated_by", "deleted_at", "deleted_by", "activity_log") VALUES ((SELECT "contact_type_id" FROM "contact_type" WHERE "code" = 'LAND_PHONE_NUMBER'), (SELECT "party_id" FROM "party" WHERE "party_type_id" = 'ORGANIZATION' AND "party_name" = 'Orgnization Name'), '0523 852 9945', NULL, NULL, NULL, NULL, NULL, NULL);
 ;
-INSERT INTO "contact_land" ("contact_type_id", "party_id", "address_line1", "address_line2", "address_zip", "address_city", "address_state", "address_country", "created_by", "updated_at", "updated_by", "deleted_at", "deleted_by", "activity_log") VALUES ('OFFICIAL_ADDRESS', (SELECT "party_id" FROM "party" WHERE "party_type_id" = 'ORGANIZATION' AND "party_name" = 'Orgnization Name'), 'Address line 1', 'Address line 2', '', 'City', 'State', 'Country', NULL, NULL, NULL, NULL, NULL, NULL);
+INSERT INTO "contact_land" ("contact_type_id", "party_id", "address_line1", "address_line2", "address_zip", "address_city", "address_state", "address_country", "created_by", "updated_at", "updated_by", "deleted_at", "deleted_by", "activity_log") VALUES ((SELECT "contact_type_id" FROM "contact_type" WHERE "code" = 'OFFICIAL_ADDRESS'), (SELECT "party_id" FROM "party" WHERE "party_type_id" = 'ORGANIZATION' AND "party_name" = 'Orgnization Name'), 'Address line 1', 'Address line 2', '', 'City', 'State', 'Country', NULL, NULL, NULL, NULL, NULL, NULL);
 INSERT INTO "party" ("party_type_id", "party_name", "created_by", "updated_at", "updated_by", "deleted_at", "deleted_by", "activity_log") VALUES ('PERSON', 'First Name Last Name', NULL, NULL, NULL, NULL, NULL, NULL);
-INSERT INTO "person" ("party_id", "person_type_id", "person_first_name", "person_last_name", "honorific_prefix", "honorific_suffix", "created_by", "updated_at", "updated_by", "deleted_at", "deleted_by", "activity_log") VALUES ((SELECT "party_id" FROM "party" WHERE "party_type_id" = 'PERSON' AND "party_name" = 'First Name Last Name'), 'INDIVIDUAL', 'First Name', 'Last Name', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
-INSERT INTO "contact_electronic" ("contact_type_id", "party_id", "electronics_details", "created_by", "updated_at", "updated_by", "deleted_at", "deleted_by", "activity_log") VALUES ('OFFICIAL_EMAIL', (SELECT "party_id" FROM "party" WHERE "party_type_id" = 'PERSON' AND "party_name" = 'First Name Last Name'), 'person@org.com', NULL, NULL, NULL, NULL, NULL, NULL);
-INSERT INTO "contact_electronic" ("contact_type_id", "party_id", "electronics_details", "created_by", "updated_at", "updated_by", "deleted_at", "deleted_by", "activity_log") VALUES ('MOBILE_PHONE_NUMBER', (SELECT "party_id" FROM "party" WHERE "party_type_id" = 'PERSON' AND "party_name" = 'First Name Last Name'), '+911234567890', NULL, NULL, NULL, NULL, NULL, NULL);
+INSERT INTO "person" ("party_id", "person_type_id", "person_first_name", "person_last_name", "honorific_prefix", "honorific_suffix", "created_by", "updated_at", "updated_by", "deleted_at", "deleted_by", "activity_log") VALUES ((SELECT "party_id" FROM "party" WHERE "party_type_id" = 'PERSON' AND "party_name" = 'First Name Last Name'), (SELECT "person_type_id" FROM "person_type" WHERE "code" = 'INDIVIDUAL'), 'First Name', 'Last Name', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+INSERT INTO "contact_electronic" ("contact_type_id", "party_id", "electronics_details", "created_by", "updated_at", "updated_by", "deleted_at", "deleted_by", "activity_log") VALUES ((SELECT "contact_type_id" FROM "contact_type" WHERE "code" = 'OFFICIAL_EMAIL'), (SELECT "party_id" FROM "party" WHERE "party_type_id" = 'PERSON' AND "party_name" = 'First Name Last Name'), 'person@org.com', NULL, NULL, NULL, NULL, NULL, NULL);
+INSERT INTO "contact_electronic" ("contact_type_id", "party_id", "electronics_details", "created_by", "updated_at", "updated_by", "deleted_at", "deleted_by", "activity_log") VALUES ((SELECT "contact_type_id" FROM "contact_type" WHERE "code" = 'MOBILE_PHONE_NUMBER'), (SELECT "party_id" FROM "party" WHERE "party_type_id" = 'PERSON' AND "party_name" = 'First Name Last Name'), '+911234567890', NULL, NULL, NULL, NULL, NULL, NULL);
 ;
-INSERT INTO "contact_land" ("contact_type_id", "party_id", "address_line1", "address_line2", "address_zip", "address_city", "address_state", "address_country", "created_by", "updated_at", "updated_by", "deleted_at", "deleted_by", "activity_log") VALUES ('OFFICIAL_ADDRESS', (SELECT "party_id" FROM "party" WHERE "party_type_id" = 'PERSON' AND "party_name" = 'First Name Last Name'), 'Address line 1', 'Address line 2', '', 'City', 'State', 'Country', NULL, NULL, NULL, NULL, NULL, NULL);
+INSERT INTO "contact_land" ("contact_type_id", "party_id", "address_line1", "address_line2", "address_zip", "address_city", "address_state", "address_country", "created_by", "updated_at", "updated_by", "deleted_at", "deleted_by", "activity_log") VALUES ((SELECT "contact_type_id" FROM "contact_type" WHERE "code" = 'OFFICIAL_ADDRESS'), (SELECT "party_id" FROM "party" WHERE "party_type_id" = 'PERSON' AND "party_name" = 'First Name Last Name'), 'Address line 1', 'Address line 2', '', 'City', 'State', 'Country', NULL, NULL, NULL, NULL, NULL, NULL);
 ;
-INSERT INTO "party_relation" ("party_id", "related_party_id", "relation_type_id", "party_role_id", "created_by", "updated_at", "updated_by", "deleted_at", "deleted_by", "activity_log") VALUES ((SELECT "party_id" FROM "party" WHERE "party_type_id" = 'PERSON' AND "party_name" = 'First Name Last Name'), (SELECT "party_id" FROM "party" WHERE "party_type_id" = 'ORGANIZATION' AND "party_name" = 'Orgnization Name'), 'ORGANIZATION_TO_PERSON', 'VENDOR', NULL, NULL, NULL, NULL, NULL, NULL);
-INSERT INTO "organization_role" ("person_id", "organization_id", "organization_role_type_id", "created_by", "updated_at", "updated_by", "deleted_at", "deleted_by", "activity_log") VALUES ((SELECT "person_id" FROM "person" WHERE "party_id" = (SELECT "party_id" FROM "party" WHERE "party_type_id" = 'PERSON' AND "party_name" = 'First Name Last Name') AND "person_type_id" = 'INDIVIDUAL' AND "person_first_name" = 'First Name' AND "person_last_name" = 'Last Name'), (SELECT "organization_id" FROM "organization" WHERE "name" = 'Orgnization Name' AND "license" = 'XXXX-XXXXX-XXXX'), (SELECT "organization_role_type_id" FROM "organization_role_type" WHERE "code" = 'LEAD_SOFTWARE_ENGINEER'), NULL, NULL, NULL, NULL, NULL, NULL);
-INSERT INTO "person_skill" ("person_id", "skill_nature_id", "skill_id", "proficiency_scale_id", "created_by", "updated_at", "updated_by", "deleted_at", "deleted_by", "activity_log") VALUES ((SELECT "person_id" FROM "person" WHERE "party_id" = (SELECT "party_id" FROM "party" WHERE "party_type_id" = 'PERSON' AND "party_name" = 'First Name Last Name') AND "person_type_id" = 'INDIVIDUAL' AND "person_first_name" = 'First Name' AND "person_last_name" = 'Last Name'), 'SOFTWARE', 'REACTJS', 'INTERMEDIATE', NULL, NULL, NULL, NULL, NULL, NULL);
-INSERT INTO "person_skill" ("person_id", "skill_nature_id", "skill_id", "proficiency_scale_id", "created_by", "updated_at", "updated_by", "deleted_at", "deleted_by", "activity_log") VALUES ((SELECT "person_id" FROM "person" WHERE "party_id" = (SELECT "party_id" FROM "party" WHERE "party_type_id" = 'PERSON' AND "party_name" = 'First Name Last Name') AND "person_type_id" = 'INDIVIDUAL' AND "person_first_name" = 'First Name' AND "person_last_name" = 'Last Name'), 'SOFTWARE', 'JAVASCRIPT', 'ADVANCED', NULL, NULL, NULL, NULL, NULL, NULL);
-INSERT INTO "person_skill" ("person_id", "skill_nature_id", "skill_id", "proficiency_scale_id", "created_by", "updated_at", "updated_by", "deleted_at", "deleted_by", "activity_log") VALUES ((SELECT "person_id" FROM "person" WHERE "party_id" = (SELECT "party_id" FROM "party" WHERE "party_type_id" = 'PERSON' AND "party_name" = 'First Name Last Name') AND "person_type_id" = 'INDIVIDUAL' AND "person_first_name" = 'First Name' AND "person_last_name" = 'Last Name'), 'SOFTWARE', 'HUGO', 'FUNDAMENTAL_AWARENESS', NULL, NULL, NULL, NULL, NULL, NULL);
-INSERT INTO "person_skill" ("person_id", "skill_nature_id", "skill_id", "proficiency_scale_id", "created_by", "updated_at", "updated_by", "deleted_at", "deleted_by", "activity_log") VALUES ((SELECT "person_id" FROM "person" WHERE "party_id" = (SELECT "party_id" FROM "party" WHERE "party_type_id" = 'PERSON' AND "party_name" = 'First Name Last Name') AND "person_type_id" = 'INDIVIDUAL' AND "person_first_name" = 'First Name' AND "person_last_name" = 'Last Name'), 'SOFTWARE', 'DENO', 'INTERMEDIATE', NULL, NULL, NULL, NULL, NULL, NULL);
-INSERT INTO "person_skill" ("person_id", "skill_nature_id", "skill_id", "proficiency_scale_id", "created_by", "updated_at", "updated_by", "deleted_at", "deleted_by", "activity_log") VALUES ((SELECT "person_id" FROM "person" WHERE "party_id" = (SELECT "party_id" FROM "party" WHERE "party_type_id" = 'PERSON' AND "party_name" = 'First Name Last Name') AND "person_type_id" = 'INDIVIDUAL' AND "person_first_name" = 'First Name' AND "person_last_name" = 'Last Name'), 'SOFTWARE', 'ANGULAR', 'INTERMEDIATE', NULL, NULL, NULL, NULL, NULL, NULL);
-INSERT INTO "person_skill" ("person_id", "skill_nature_id", "skill_id", "proficiency_scale_id", "created_by", "updated_at", "updated_by", "deleted_at", "deleted_by", "activity_log") VALUES ((SELECT "person_id" FROM "person" WHERE "party_id" = (SELECT "party_id" FROM "party" WHERE "party_type_id" = 'PERSON' AND "party_name" = 'First Name Last Name') AND "person_type_id" = 'INDIVIDUAL' AND "person_first_name" = 'First Name' AND "person_last_name" = 'Last Name'), 'SOFTWARE', 'TYPESCRIPT', 'INTERMEDIATE', NULL, NULL, NULL, NULL, NULL, NULL);
-INSERT INTO "person_skill" ("person_id", "skill_nature_id", "skill_id", "proficiency_scale_id", "created_by", "updated_at", "updated_by", "deleted_at", "deleted_by", "activity_log") VALUES ((SELECT "person_id" FROM "person" WHERE "party_id" = (SELECT "party_id" FROM "party" WHERE "party_type_id" = 'PERSON' AND "party_name" = 'First Name Last Name') AND "person_type_id" = 'INDIVIDUAL' AND "person_first_name" = 'First Name' AND "person_last_name" = 'Last Name'), 'SOFTWARE', 'POSTGRESQL', 'INTERMEDIATE', NULL, NULL, NULL, NULL, NULL, NULL);
-INSERT INTO "person_skill" ("person_id", "skill_nature_id", "skill_id", "proficiency_scale_id", "created_by", "updated_at", "updated_by", "deleted_at", "deleted_by", "activity_log") VALUES ((SELECT "person_id" FROM "person" WHERE "party_id" = (SELECT "party_id" FROM "party" WHERE "party_type_id" = 'PERSON' AND "party_name" = 'First Name Last Name') AND "person_type_id" = 'INDIVIDUAL' AND "person_first_name" = 'First Name' AND "person_last_name" = 'Last Name'), 'SOFTWARE', 'MYSQL', 'INTERMEDIATE', NULL, NULL, NULL, NULL, NULL, NULL);
-INSERT INTO "person_skill" ("person_id", "skill_nature_id", "skill_id", "proficiency_scale_id", "created_by", "updated_at", "updated_by", "deleted_at", "deleted_by", "activity_log") VALUES ((SELECT "person_id" FROM "person" WHERE "party_id" = (SELECT "party_id" FROM "party" WHERE "party_type_id" = 'PERSON' AND "party_name" = 'First Name Last Name') AND "person_type_id" = 'INDIVIDUAL' AND "person_first_name" = 'First Name' AND "person_last_name" = 'Last Name'), 'SOFTWARE', 'PHP', 'INTERMEDIATE', NULL, NULL, NULL, NULL, NULL, NULL);
-INSERT INTO "person_skill" ("person_id", "skill_nature_id", "skill_id", "proficiency_scale_id", "created_by", "updated_at", "updated_by", "deleted_at", "deleted_by", "activity_log") VALUES ((SELECT "person_id" FROM "person" WHERE "party_id" = (SELECT "party_id" FROM "party" WHERE "party_type_id" = 'PERSON' AND "party_name" = 'First Name Last Name') AND "person_type_id" = 'INDIVIDUAL' AND "person_first_name" = 'First Name' AND "person_last_name" = 'Last Name'), 'SOFTWARE', 'PYTHON', 'FUNDAMENTAL_AWARENESS', NULL, NULL, NULL, NULL, NULL, NULL);
-INSERT INTO "person_skill" ("person_id", "skill_nature_id", "skill_id", "proficiency_scale_id", "created_by", "updated_at", "updated_by", "deleted_at", "deleted_by", "activity_log") VALUES ((SELECT "person_id" FROM "person" WHERE "party_id" = (SELECT "party_id" FROM "party" WHERE "party_type_id" = 'PERSON' AND "party_name" = 'First Name Last Name') AND "person_type_id" = 'INDIVIDUAL' AND "person_first_name" = 'First Name' AND "person_last_name" = 'Last Name'), 'SOFTWARE', 'DOT_NET', 'NA', NULL, NULL, NULL, NULL, NULL, NULL);
-INSERT INTO "person_skill" ("person_id", "skill_nature_id", "skill_id", "proficiency_scale_id", "created_by", "updated_at", "updated_by", "deleted_at", "deleted_by", "activity_log") VALUES ((SELECT "person_id" FROM "person" WHERE "party_id" = (SELECT "party_id" FROM "party" WHERE "party_type_id" = 'PERSON' AND "party_name" = 'First Name Last Name') AND "person_type_id" = 'INDIVIDUAL' AND "person_first_name" = 'First Name' AND "person_last_name" = 'Last Name'), 'SOFTWARE', 'ORACLE', 'NA', NULL, NULL, NULL, NULL, NULL, NULL);
-INSERT INTO "person_skill" ("person_id", "skill_nature_id", "skill_id", "proficiency_scale_id", "created_by", "updated_at", "updated_by", "deleted_at", "deleted_by", "activity_log") VALUES ((SELECT "person_id" FROM "person" WHERE "party_id" = (SELECT "party_id" FROM "party" WHERE "party_type_id" = 'PERSON' AND "party_name" = 'First Name Last Name') AND "person_type_id" = 'INDIVIDUAL' AND "person_first_name" = 'First Name' AND "person_last_name" = 'Last Name'), 'SOFTWARE', 'JAVA', 'FUNDAMENTAL_AWARENESS', NULL, NULL, NULL, NULL, NULL, NULL);
-INSERT INTO "person_skill" ("person_id", "skill_nature_id", "skill_id", "proficiency_scale_id", "created_by", "updated_at", "updated_by", "deleted_at", "deleted_by", "activity_log") VALUES ((SELECT "person_id" FROM "person" WHERE "party_id" = (SELECT "party_id" FROM "party" WHERE "party_type_id" = 'PERSON' AND "party_name" = 'First Name Last Name') AND "person_type_id" = 'INDIVIDUAL' AND "person_first_name" = 'First Name' AND "person_last_name" = 'Last Name'), 'SOFTWARE', 'JQUERY', 'ADVANCED', NULL, NULL, NULL, NULL, NULL, NULL);
-INSERT INTO "person_skill" ("person_id", "skill_nature_id", "skill_id", "proficiency_scale_id", "created_by", "updated_at", "updated_by", "deleted_at", "deleted_by", "activity_log") VALUES ((SELECT "person_id" FROM "person" WHERE "party_id" = (SELECT "party_id" FROM "party" WHERE "party_type_id" = 'PERSON' AND "party_name" = 'First Name Last Name') AND "person_type_id" = 'INDIVIDUAL' AND "person_first_name" = 'First Name' AND "person_last_name" = 'Last Name'), 'SOFTWARE', 'OSQUERY', 'FUNDAMENTAL_AWARENESS', NULL, NULL, NULL, NULL, NULL, NULL);
-INSERT INTO "organization_role_type" ("code", "value", "created_by", "updated_at", "updated_by", "deleted_at", "deleted_by", "activity_log") VALUES ('LEAD_SOFTWARE_ENGINEER', 'Lead Software Engineer', NULL, NULL, NULL, NULL, NULL, NULL);
-INSERT INTO "awareness_training" ("training_subject_id", "person_id", "organization_id", "training_status_id", "attended_date", "created_by", "updated_at", "updated_by", "deleted_at", "deleted_by", "activity_log") VALUES ('HIPAA', (SELECT "person_id" FROM "person" WHERE "party_id" = (SELECT "party_id" FROM "party" WHERE "party_type_id" = 'PERSON' AND "party_name" = 'First Name Last Name') AND "person_type_id" = 'INDIVIDUAL' AND "person_first_name" = 'First Name' AND "person_last_name" = 'Last Name'), (SELECT "organization_id" FROM "organization" WHERE "name" = 'Orgnization Name' AND "license" = 'XXXX-XXXXX-XXXX'), 'YES', '2022-02-21', NULL, NULL, NULL, NULL, NULL, NULL);
-INSERT INTO "security_incident_response_team" ("training_subject_id", "person_id", "organization_id", "training_status_id", "attended_date", "created_by", "updated_at", "updated_by", "deleted_at", "deleted_by", "activity_log") VALUES (NULL, (SELECT "person_id" FROM "person" WHERE "party_id" = (SELECT "party_id" FROM "party" WHERE "party_type_id" = 'PERSON' AND "party_name" = 'First Name Last Name') AND "person_type_id" = 'INDIVIDUAL' AND "person_first_name" = 'First Name' AND "person_last_name" = 'Last Name'), (SELECT "organization_id" FROM "organization" WHERE "name" = 'Orgnization Name' AND "license" = 'XXXX-XXXXX-XXXX'), NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
-INSERT INTO "rating" ("author_id", "rating_given_to_id", "rating_value_id", "best_rating_id", "rating_explanation", "review_aspect", "worst_rating_id", "created_by", "updated_at", "updated_by", "deleted_at", "deleted_by", "activity_log") VALUES ((SELECT "person_id" FROM "person" WHERE "party_id" = (SELECT "party_id" FROM "party" WHERE "party_type_id" = 'PERSON' AND "party_name" = 'First Name Last Name') AND "person_type_id" = 'INDIVIDUAL' AND "person_first_name" = 'First Name' AND "person_last_name" = 'Last Name'), (SELECT "organization_id" FROM "organization" WHERE "name" = 'Orgnization Name' AND "license" = 'XXXX-XXXXX-XXXX'), 'FOUR', 'FIVE', 'Good Service', 'Satisfied', 'THREE', NULL, NULL, NULL, NULL, NULL, NULL);
+INSERT INTO "party_relation" ("party_id", "related_party_id", "relation_type_id", "party_role_id", "created_by", "updated_at", "updated_by", "deleted_at", "deleted_by", "activity_log") VALUES ((SELECT "party_id" FROM "party" WHERE "party_type_id" = 'PERSON' AND "party_name" = 'First Name Last Name'), (SELECT "party_id" FROM "party" WHERE "party_type_id" = 'ORGANIZATION' AND "party_name" = 'Orgnization Name'), 'ORGANIZATION_TO_PERSON', (SELECT "party_role_id" FROM "party_role" WHERE "code" = 'VENDOR'), NULL, NULL, NULL, NULL, NULL, NULL);
+INSERT INTO "organization_role" ("person_id", "organization_id", "organization_role_type_id", "created_by", "updated_at", "updated_by", "deleted_at", "deleted_by", "activity_log") VALUES ((SELECT "person_id" FROM "person" WHERE "party_id" = (SELECT "party_id" FROM "party" WHERE "party_type_id" = 'PERSON' AND "party_name" = 'First Name Last Name') AND "person_type_id" = (SELECT "person_type_id" FROM "person_type" WHERE "code" = 'INDIVIDUAL') AND "person_first_name" = 'First Name' AND "person_last_name" = 'Last Name'), (SELECT "organization_id" FROM "organization" WHERE "name" = 'Orgnization Name' AND "license" = 'XXXX-XXXXX-XXXX'), (SELECT "organization_role_type_id" FROM "organization_role_type" WHERE "code" = 'LEAD_SOFTWARE_ENGINEER'), NULL, NULL, NULL, NULL, NULL, NULL);
+INSERT INTO "person_skill" ("person_id", "skill_nature_id", "skill_id", "proficiency_scale_id", "created_by", "updated_at", "updated_by", "deleted_at", "deleted_by", "activity_log") VALUES ((SELECT "person_id" FROM "person" WHERE "party_id" = (SELECT "party_id" FROM "party" WHERE "party_type_id" = 'PERSON' AND "party_name" = 'First Name Last Name') AND "person_type_id" = (SELECT "person_type_id" FROM "person_type" WHERE "code" = 'INDIVIDUAL') AND "person_first_name" = 'First Name' AND "person_last_name" = 'Last Name'), 'SOFTWARE', 'REACTJS', 'INTERMEDIATE', NULL, NULL, NULL, NULL, NULL, NULL);
+INSERT INTO "person_skill" ("person_id", "skill_nature_id", "skill_id", "proficiency_scale_id", "created_by", "updated_at", "updated_by", "deleted_at", "deleted_by", "activity_log") VALUES ((SELECT "person_id" FROM "person" WHERE "party_id" = (SELECT "party_id" FROM "party" WHERE "party_type_id" = 'PERSON' AND "party_name" = 'First Name Last Name') AND "person_type_id" = (SELECT "person_type_id" FROM "person_type" WHERE "code" = 'INDIVIDUAL') AND "person_first_name" = 'First Name' AND "person_last_name" = 'Last Name'), 'SOFTWARE', 'JAVASCRIPT', 'ADVANCED', NULL, NULL, NULL, NULL, NULL, NULL);
+INSERT INTO "person_skill" ("person_id", "skill_nature_id", "skill_id", "proficiency_scale_id", "created_by", "updated_at", "updated_by", "deleted_at", "deleted_by", "activity_log") VALUES ((SELECT "person_id" FROM "person" WHERE "party_id" = (SELECT "party_id" FROM "party" WHERE "party_type_id" = 'PERSON' AND "party_name" = 'First Name Last Name') AND "person_type_id" = (SELECT "person_type_id" FROM "person_type" WHERE "code" = 'INDIVIDUAL') AND "person_first_name" = 'First Name' AND "person_last_name" = 'Last Name'), 'SOFTWARE', 'HUGO', 'FUNDAMENTAL_AWARENESS', NULL, NULL, NULL, NULL, NULL, NULL);
+INSERT INTO "person_skill" ("person_id", "skill_nature_id", "skill_id", "proficiency_scale_id", "created_by", "updated_at", "updated_by", "deleted_at", "deleted_by", "activity_log") VALUES ((SELECT "person_id" FROM "person" WHERE "party_id" = (SELECT "party_id" FROM "party" WHERE "party_type_id" = 'PERSON' AND "party_name" = 'First Name Last Name') AND "person_type_id" = (SELECT "person_type_id" FROM "person_type" WHERE "code" = 'INDIVIDUAL') AND "person_first_name" = 'First Name' AND "person_last_name" = 'Last Name'), 'SOFTWARE', 'DENO', 'INTERMEDIATE', NULL, NULL, NULL, NULL, NULL, NULL);
+INSERT INTO "person_skill" ("person_id", "skill_nature_id", "skill_id", "proficiency_scale_id", "created_by", "updated_at", "updated_by", "deleted_at", "deleted_by", "activity_log") VALUES ((SELECT "person_id" FROM "person" WHERE "party_id" = (SELECT "party_id" FROM "party" WHERE "party_type_id" = 'PERSON' AND "party_name" = 'First Name Last Name') AND "person_type_id" = (SELECT "person_type_id" FROM "person_type" WHERE "code" = 'INDIVIDUAL') AND "person_first_name" = 'First Name' AND "person_last_name" = 'Last Name'), 'SOFTWARE', 'ANGULAR', 'INTERMEDIATE', NULL, NULL, NULL, NULL, NULL, NULL);
+INSERT INTO "person_skill" ("person_id", "skill_nature_id", "skill_id", "proficiency_scale_id", "created_by", "updated_at", "updated_by", "deleted_at", "deleted_by", "activity_log") VALUES ((SELECT "person_id" FROM "person" WHERE "party_id" = (SELECT "party_id" FROM "party" WHERE "party_type_id" = 'PERSON' AND "party_name" = 'First Name Last Name') AND "person_type_id" = (SELECT "person_type_id" FROM "person_type" WHERE "code" = 'INDIVIDUAL') AND "person_first_name" = 'First Name' AND "person_last_name" = 'Last Name'), 'SOFTWARE', 'TYPESCRIPT', 'INTERMEDIATE', NULL, NULL, NULL, NULL, NULL, NULL);
+INSERT INTO "person_skill" ("person_id", "skill_nature_id", "skill_id", "proficiency_scale_id", "created_by", "updated_at", "updated_by", "deleted_at", "deleted_by", "activity_log") VALUES ((SELECT "person_id" FROM "person" WHERE "party_id" = (SELECT "party_id" FROM "party" WHERE "party_type_id" = 'PERSON' AND "party_name" = 'First Name Last Name') AND "person_type_id" = (SELECT "person_type_id" FROM "person_type" WHERE "code" = 'INDIVIDUAL') AND "person_first_name" = 'First Name' AND "person_last_name" = 'Last Name'), 'SOFTWARE', 'POSTGRESQL', 'INTERMEDIATE', NULL, NULL, NULL, NULL, NULL, NULL);
+INSERT INTO "person_skill" ("person_id", "skill_nature_id", "skill_id", "proficiency_scale_id", "created_by", "updated_at", "updated_by", "deleted_at", "deleted_by", "activity_log") VALUES ((SELECT "person_id" FROM "person" WHERE "party_id" = (SELECT "party_id" FROM "party" WHERE "party_type_id" = 'PERSON' AND "party_name" = 'First Name Last Name') AND "person_type_id" = (SELECT "person_type_id" FROM "person_type" WHERE "code" = 'INDIVIDUAL') AND "person_first_name" = 'First Name' AND "person_last_name" = 'Last Name'), 'SOFTWARE', 'MYSQL', 'INTERMEDIATE', NULL, NULL, NULL, NULL, NULL, NULL);
+INSERT INTO "person_skill" ("person_id", "skill_nature_id", "skill_id", "proficiency_scale_id", "created_by", "updated_at", "updated_by", "deleted_at", "deleted_by", "activity_log") VALUES ((SELECT "person_id" FROM "person" WHERE "party_id" = (SELECT "party_id" FROM "party" WHERE "party_type_id" = 'PERSON' AND "party_name" = 'First Name Last Name') AND "person_type_id" = (SELECT "person_type_id" FROM "person_type" WHERE "code" = 'INDIVIDUAL') AND "person_first_name" = 'First Name' AND "person_last_name" = 'Last Name'), 'SOFTWARE', 'PHP', 'INTERMEDIATE', NULL, NULL, NULL, NULL, NULL, NULL);
+INSERT INTO "person_skill" ("person_id", "skill_nature_id", "skill_id", "proficiency_scale_id", "created_by", "updated_at", "updated_by", "deleted_at", "deleted_by", "activity_log") VALUES ((SELECT "person_id" FROM "person" WHERE "party_id" = (SELECT "party_id" FROM "party" WHERE "party_type_id" = 'PERSON' AND "party_name" = 'First Name Last Name') AND "person_type_id" = (SELECT "person_type_id" FROM "person_type" WHERE "code" = 'INDIVIDUAL') AND "person_first_name" = 'First Name' AND "person_last_name" = 'Last Name'), 'SOFTWARE', 'PYTHON', 'FUNDAMENTAL_AWARENESS', NULL, NULL, NULL, NULL, NULL, NULL);
+INSERT INTO "person_skill" ("person_id", "skill_nature_id", "skill_id", "proficiency_scale_id", "created_by", "updated_at", "updated_by", "deleted_at", "deleted_by", "activity_log") VALUES ((SELECT "person_id" FROM "person" WHERE "party_id" = (SELECT "party_id" FROM "party" WHERE "party_type_id" = 'PERSON' AND "party_name" = 'First Name Last Name') AND "person_type_id" = (SELECT "person_type_id" FROM "person_type" WHERE "code" = 'INDIVIDUAL') AND "person_first_name" = 'First Name' AND "person_last_name" = 'Last Name'), 'SOFTWARE', 'DOT_NET', 'NA', NULL, NULL, NULL, NULL, NULL, NULL);
+INSERT INTO "person_skill" ("person_id", "skill_nature_id", "skill_id", "proficiency_scale_id", "created_by", "updated_at", "updated_by", "deleted_at", "deleted_by", "activity_log") VALUES ((SELECT "person_id" FROM "person" WHERE "party_id" = (SELECT "party_id" FROM "party" WHERE "party_type_id" = 'PERSON' AND "party_name" = 'First Name Last Name') AND "person_type_id" = (SELECT "person_type_id" FROM "person_type" WHERE "code" = 'INDIVIDUAL') AND "person_first_name" = 'First Name' AND "person_last_name" = 'Last Name'), 'SOFTWARE', 'ORACLE', 'NA', NULL, NULL, NULL, NULL, NULL, NULL);
+INSERT INTO "person_skill" ("person_id", "skill_nature_id", "skill_id", "proficiency_scale_id", "created_by", "updated_at", "updated_by", "deleted_at", "deleted_by", "activity_log") VALUES ((SELECT "person_id" FROM "person" WHERE "party_id" = (SELECT "party_id" FROM "party" WHERE "party_type_id" = 'PERSON' AND "party_name" = 'First Name Last Name') AND "person_type_id" = (SELECT "person_type_id" FROM "person_type" WHERE "code" = 'INDIVIDUAL') AND "person_first_name" = 'First Name' AND "person_last_name" = 'Last Name'), 'SOFTWARE', 'JAVA', 'FUNDAMENTAL_AWARENESS', NULL, NULL, NULL, NULL, NULL, NULL);
+INSERT INTO "person_skill" ("person_id", "skill_nature_id", "skill_id", "proficiency_scale_id", "created_by", "updated_at", "updated_by", "deleted_at", "deleted_by", "activity_log") VALUES ((SELECT "person_id" FROM "person" WHERE "party_id" = (SELECT "party_id" FROM "party" WHERE "party_type_id" = 'PERSON' AND "party_name" = 'First Name Last Name') AND "person_type_id" = (SELECT "person_type_id" FROM "person_type" WHERE "code" = 'INDIVIDUAL') AND "person_first_name" = 'First Name' AND "person_last_name" = 'Last Name'), 'SOFTWARE', 'JQUERY', 'ADVANCED', NULL, NULL, NULL, NULL, NULL, NULL);
+INSERT INTO "person_skill" ("person_id", "skill_nature_id", "skill_id", "proficiency_scale_id", "created_by", "updated_at", "updated_by", "deleted_at", "deleted_by", "activity_log") VALUES ((SELECT "person_id" FROM "person" WHERE "party_id" = (SELECT "party_id" FROM "party" WHERE "party_type_id" = 'PERSON' AND "party_name" = 'First Name Last Name') AND "person_type_id" = (SELECT "person_type_id" FROM "person_type" WHERE "code" = 'INDIVIDUAL') AND "person_first_name" = 'First Name' AND "person_last_name" = 'Last Name'), 'SOFTWARE', 'OSQUERY', 'FUNDAMENTAL_AWARENESS', NULL, NULL, NULL, NULL, NULL, NULL);
+INSERT INTO "awareness_training" ("training_subject_id", "person_id", "organization_id", "training_status_id", "attended_date", "created_by", "updated_at", "updated_by", "deleted_at", "deleted_by", "activity_log") VALUES ('HIPAA', (SELECT "person_id" FROM "person" WHERE "party_id" = (SELECT "party_id" FROM "party" WHERE "party_type_id" = 'PERSON' AND "party_name" = 'First Name Last Name') AND "person_type_id" = (SELECT "person_type_id" FROM "person_type" WHERE "code" = 'INDIVIDUAL') AND "person_first_name" = 'First Name' AND "person_last_name" = 'Last Name'), (SELECT "organization_id" FROM "organization" WHERE "name" = 'Orgnization Name' AND "license" = 'XXXX-XXXXX-XXXX'), 'YES', '2022-02-21', NULL, NULL, NULL, NULL, NULL, NULL);
+INSERT INTO "security_incident_response_team" ("training_subject_id", "person_id", "organization_id", "training_status_id", "attended_date", "created_by", "updated_at", "updated_by", "deleted_at", "deleted_by", "activity_log") VALUES (NULL, (SELECT "person_id" FROM "person" WHERE "party_id" = (SELECT "party_id" FROM "party" WHERE "party_type_id" = 'PERSON' AND "party_name" = 'First Name Last Name') AND "person_type_id" = (SELECT "person_type_id" FROM "person_type" WHERE "code" = 'INDIVIDUAL') AND "person_first_name" = 'First Name' AND "person_last_name" = 'Last Name'), (SELECT "organization_id" FROM "organization" WHERE "name" = 'Orgnization Name' AND "license" = 'XXXX-XXXXX-XXXX'), NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+INSERT INTO "rating" ("author_id", "rating_given_to_id", "rating_value_id", "best_rating_id", "rating_explanation", "review_aspect", "worst_rating_id", "created_by", "updated_at", "updated_by", "deleted_at", "deleted_by", "activity_log") VALUES ((SELECT "person_id" FROM "person" WHERE "party_id" = (SELECT "party_id" FROM "party" WHERE "party_type_id" = 'PERSON' AND "party_name" = 'First Name Last Name') AND "person_type_id" = (SELECT "person_type_id" FROM "person_type" WHERE "code" = 'INDIVIDUAL') AND "person_first_name" = 'First Name' AND "person_last_name" = 'Last Name'), (SELECT "organization_id" FROM "organization" WHERE "name" = 'Orgnization Name' AND "license" = 'XXXX-XXXXX-XXXX'), 'FOUR', 'FIVE', 'Good Service', 'Satisfied', 'THREE', NULL, NULL, NULL, NULL, NULL, NULL);
 INSERT INTO "contract" ("contract_from_id", "contract_to_id", "contract_status_id", "document_reference", "payment_type_id", "periodicity_id", "start_date", "end_date", "contract_type_id", "date_of_last_review", "date_of_next_review", "date_of_contract_review", "date_of_contract_approval", "created_by", "updated_at", "updated_by", "deleted_at", "deleted_by", "activity_log") VALUES ((SELECT "party_id" FROM "party" WHERE "party_type_id" = 'PERSON' AND "party_name" = 'First Name Last Name'), (SELECT "party_id" FROM "party" WHERE "party_type_id" = 'ORGANIZATION' AND "party_name" = 'Orgnization Name'), 'FINISHED', 'google.com', 'RENTS', 'WEEKLY', '2021-04-20T00:00:00.000Z', '2021-04-20T00:00:00.000Z', 'GENERAL_CONTRACT_FOR_SERVICES', '2021-04-20T00:00:00.000Z', '2021-04-20T00:00:00.000Z', '2021-04-20T00:00:00.000Z', '2021-04-20T00:00:00.000Z', NULL, NULL, NULL, NULL, NULL, NULL);
-INSERT INTO "risk_register" ("description", "risk_subject_id", "risk_type_id", "impact_to_the_organization", "rating_likelihood_id", "rating_impact_id", "rating_overall_risk_id", "controls_in_place", "control_effectivenes", "over_all_residual_risk_rating_id", "mitigation_further_actions", "control_monitor_mitigation_actions_tracking_strategy", "control_monitor_action_due_date", "control_monitor_risk_owner_id", "created_by", "updated_at", "updated_by", "deleted_at", "deleted_by", "activity_log") VALUES ('Risk description', 'TECHNICAL_RISK', 'QUALITY', 'Impact to the organization', 'THREE', 'THREE', 'THREE', 'Try forgot password', 1, NULL, 'Mitigation further actions', 'Control monitor mitigation actions tracking strategy', '2022-06-13', (SELECT "person_id" FROM "person" WHERE "party_id" = (SELECT "party_id" FROM "party" WHERE "party_type_id" = 'PERSON' AND "party_name" = 'First Name Last Name') AND "person_type_id" = 'INDIVIDUAL' AND "person_first_name" = 'First Name' AND "person_last_name" = 'Last Name'), NULL, NULL, NULL, NULL, NULL, NULL);
+INSERT INTO "risk_register" ("description", "risk_subject_id", "risk_type_id", "impact_to_the_organization", "rating_likelihood_id", "rating_impact_id", "rating_overall_risk_id", "controls_in_place", "control_effectivenes", "over_all_residual_risk_rating_id", "mitigation_further_actions", "control_monitor_mitigation_actions_tracking_strategy", "control_monitor_action_due_date", "control_monitor_risk_owner_id", "created_by", "updated_at", "updated_by", "deleted_at", "deleted_by", "activity_log") VALUES ('Risk description', 'TECHNICAL_RISK', 'QUALITY', 'Impact to the organization', 'THREE', 'THREE', 'THREE', 'Try forgot password', 1, NULL, 'Mitigation further actions', 'Control monitor mitigation actions tracking strategy', '2022-06-13', (SELECT "person_id" FROM "person" WHERE "party_id" = (SELECT "party_id" FROM "party" WHERE "party_type_id" = 'PERSON' AND "party_name" = 'First Name Last Name') AND "person_type_id" = (SELECT "person_type_id" FROM "person_type" WHERE "code" = 'INDIVIDUAL') AND "person_first_name" = 'First Name' AND "person_last_name" = 'Last Name'), NULL, NULL, NULL, NULL, NULL, NULL);
 INSERT INTO "asset" ("organization_id", "asset_retired_date", "asset_status_id", "asset_tag", "name", "description", "asset_type_id", "asset_workload_category", "assignment_id", "barcode_or_rfid_tag", "installed_date", "planned_retirement_date", "purchase_delivery_date", "purchase_order_date", "purchase_request_date", "serial_number", "tco_amount", "tco_currency", "created_by", "updated_at", "updated_by", "deleted_at", "deleted_by", "activity_log") VALUES ((SELECT "organization_id" FROM "organization" WHERE "name" = 'Orgnization Name' AND "license" = 'XXXX-XXXXX-XXXX'), NULL, 'IN_USE', '', 'Asset Name', 'Service used for asset etc', 'VIRTUAL_MACHINE', '', 'IN_USE', '', '2021-04-20', NULL, '2021-04-20', '2021-04-20', '2021-04-20', '', '100', 'dollar', NULL, NULL, NULL, NULL, NULL, NULL);
-INSERT INTO "incident" ("title", "incident_date", "time_and_time_zone", "asset_id", "category_id", "sub_category_id", "severity_id", "priority_id", "internal_or_external_id", "location", "it_service_impacted", "impacted_modules", "impacted_dept", "reported_by_id", "reported_to_id", "brief_description", "detailed_description", "assigned_to_id", "assigned_date", "investigation_details", "containment_details", "eradication_details", "business_impact", "lessons_learned", "status_id", "closed_date", "reopened_time", "feedback_from_business", "reported_to_regulatory", "report_date", "report_time", "created_by", "updated_at", "updated_by", "deleted_at", "deleted_by", "activity_log") VALUES ('Server Down - Due to CPU utilization reached 100%', '2021-04-20', '2021-04-20T00:00:00.000Z', (SELECT "asset_id" FROM "asset" WHERE "name" = 'Asset Name' AND "description" = 'Service used for asset etc' AND "asset_type_id" = 'VIRTUAL_MACHINE'), 'PERFORMANCE', 'HARDWARE_FAILURE', 'MAJOR', 'HIGH', 'COMPLAINT', 'USA', 'Application down', '', 'All', (SELECT "person_id" FROM "person" WHERE "party_id" = (SELECT "party_id" FROM "party" WHERE "party_type_id" = 'PERSON' AND "party_name" = 'First Name Last Name') AND "person_type_id" = 'INDIVIDUAL' AND "person_first_name" = 'First Name' AND "person_last_name" = 'Last Name'), (SELECT "person_id" FROM "person" WHERE "party_id" = (SELECT "party_id" FROM "party" WHERE "party_type_id" = 'PERSON' AND "party_name" = 'First Name Last Name') AND "person_type_id" = 'INDIVIDUAL' AND "person_first_name" = 'First Name' AND "person_last_name" = 'Last Name'), 'Server will down due to CPU utilization', 'We got an alert message of server due to CPU utilization reaching 100% on 02-07-2022 07:30 GTM', (SELECT "person_id" FROM "person" WHERE "party_id" = (SELECT "party_id" FROM "party" WHERE "party_type_id" = 'PERSON' AND "party_name" = 'First Name Last Name') AND "person_type_id" = 'INDIVIDUAL' AND "person_first_name" = 'First Name' AND "person_last_name" = 'Last Name'), '2021-04-20', 'Server was facing issue using due to insufficient harware specfication which cause high CPU utilization, resulting in Crashing of the application', 'Migrated few services to another server in that network range and Restarted server', 'Migrated few services to another server in that network range', 'Application was completely down', 'We need to evlaute the hardware specification and remaining CPU/Memory resources before deploying new applications', 'CLOSED', NULL, NULL, '', '', '2021-04-20', '2021-04-20T00:00:00.000Z', NULL, NULL, NULL, NULL, NULL, NULL);
+INSERT INTO "incident" ("title", "incident_date", "time_and_time_zone", "asset_id", "category_id", "sub_category_id", "severity_id", "priority_id", "internal_or_external_id", "location", "it_service_impacted", "impacted_modules", "impacted_dept", "reported_by_id", "reported_to_id", "brief_description", "detailed_description", "assigned_to_id", "assigned_date", "investigation_details", "containment_details", "eradication_details", "business_impact", "lessons_learned", "status_id", "closed_date", "reopened_time", "feedback_from_business", "reported_to_regulatory", "report_date", "report_time", "created_by", "updated_at", "updated_by", "deleted_at", "deleted_by", "activity_log") VALUES ('Server Down - Due to CPU utilization reached 100%', '2021-04-20', '2021-04-20T00:00:00.000Z', (SELECT "asset_id" FROM "asset" WHERE "name" = 'Asset Name' AND "description" = 'Service used for asset etc' AND "asset_type_id" = 'VIRTUAL_MACHINE'), 'PERFORMANCE', 'HARDWARE_FAILURE', 'MAJOR', 'HIGH', 'COMPLAINT', 'USA', 'Application down', '', 'All', (SELECT "person_id" FROM "person" WHERE "party_id" = (SELECT "party_id" FROM "party" WHERE "party_type_id" = 'PERSON' AND "party_name" = 'First Name Last Name') AND "person_type_id" = (SELECT "person_type_id" FROM "person_type" WHERE "code" = 'INDIVIDUAL') AND "person_first_name" = 'First Name' AND "person_last_name" = 'Last Name'), (SELECT "person_id" FROM "person" WHERE "party_id" = (SELECT "party_id" FROM "party" WHERE "party_type_id" = 'PERSON' AND "party_name" = 'First Name Last Name') AND "person_type_id" = (SELECT "person_type_id" FROM "person_type" WHERE "code" = 'INDIVIDUAL') AND "person_first_name" = 'First Name' AND "person_last_name" = 'Last Name'), 'Server will down due to CPU utilization', 'We got an alert message of server due to CPU utilization reaching 100% on 02-07-2022 07:30 GTM', (SELECT "person_id" FROM "person" WHERE "party_id" = (SELECT "party_id" FROM "party" WHERE "party_type_id" = 'PERSON' AND "party_name" = 'First Name Last Name') AND "person_type_id" = (SELECT "person_type_id" FROM "person_type" WHERE "code" = 'INDIVIDUAL') AND "person_first_name" = 'First Name' AND "person_last_name" = 'Last Name'), '2021-04-20', 'Server was facing issue using due to insufficient harware specfication which cause high CPU utilization, resulting in Crashing of the application', 'Migrated few services to another server in that network range and Restarted server', 'Migrated few services to another server in that network range', 'Application was completely down', 'We need to evlaute the hardware specification and remaining CPU/Memory resources before deploying new applications', 'CLOSED', NULL, NULL, '', '', '2021-04-20', '2021-04-20T00:00:00.000Z', NULL, NULL, NULL, NULL, NULL, NULL);
 INSERT INTO "incident_root_cause" ("incident_id", "source", "description", "probability_id", "testing_analysis", "solution", "likelihood_of_risk_id", "modification_of_the_reported_issue", "testing_for_modified_issue", "test_results", "created_by", "updated_at", "updated_by", "deleted_at", "deleted_by", "activity_log") VALUES ((SELECT "incident_id" FROM "incident" WHERE "title" = 'Server Down - Due to CPU utilization reached 100%' AND "sub_category_id" = 'HARDWARE_FAILURE' AND "severity_id" = 'MAJOR' AND "priority_id" = 'HIGH' AND "internal_or_external_id" = 'COMPLAINT' AND "location" = 'USA'), 'Server', 'Sample description', 'HIGH', 'Sample testing analysis', 'Server restarted', 'HIGH', 'No modifications', 'Sample test case', 'Sample test result', NULL, NULL, NULL, NULL, NULL, NULL);
 -- the .dump in the last line is necessary because we load into :memory:
 -- first because performance is better and then emit all the SQL for saving

--- a/examples/infra-assurance/ia-example.omc.sqla.fixture.sql
+++ b/examples/infra-assurance/ia-example.omc.sqla.fixture.sql
@@ -11,11 +11,6 @@ CREATE TABLE IF NOT EXISTS "party_type" (
     "value" TEXT NOT NULL,
     "created_at" TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 );
-CREATE TABLE IF NOT EXISTS "party_role_type" (
-    "code" TEXT PRIMARY KEY NOT NULL,
-    "value" TEXT NOT NULL,
-    "created_at" TIMESTAMP DEFAULT CURRENT_TIMESTAMP
-);
 CREATE TABLE IF NOT EXISTS "contract_status" (
     "code" TEXT PRIMARY KEY NOT NULL,
     "value" TEXT NOT NULL,
@@ -151,21 +146,6 @@ CREATE TABLE IF NOT EXISTS "party_relation_type" (
     "value" TEXT NOT NULL,
     "created_at" TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 );
-CREATE TABLE IF NOT EXISTS "party_identifier_type" (
-    "code" TEXT PRIMARY KEY NOT NULL,
-    "value" TEXT NOT NULL,
-    "created_at" TIMESTAMP DEFAULT CURRENT_TIMESTAMP
-);
-CREATE TABLE IF NOT EXISTS "person_type" (
-    "code" TEXT PRIMARY KEY NOT NULL,
-    "value" TEXT NOT NULL,
-    "created_at" TIMESTAMP DEFAULT CURRENT_TIMESTAMP
-);
-CREATE TABLE IF NOT EXISTS "contact_type" (
-    "code" TEXT PRIMARY KEY NOT NULL,
-    "value" TEXT NOT NULL,
-    "created_at" TIMESTAMP DEFAULT CURRENT_TIMESTAMP
-);
 CREATE TABLE IF NOT EXISTS "training_subject" (
     "code" TEXT PRIMARY KEY NOT NULL,
     "value" TEXT NOT NULL,
@@ -238,6 +218,58 @@ CREATE TABLE IF NOT EXISTS "asset_risk_type" (
 );
 
 -- content tables
+CREATE TABLE IF NOT EXISTS "party_role" (
+    "party_role_id" INTEGER PRIMARY KEY AUTOINCREMENT,
+    "code" TEXT /* UNIQUE COLUMN */ NOT NULL,
+    "value" TEXT NOT NULL,
+    "created_at" TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    "created_by" TEXT DEFAULT 'UNKNOWN',
+    "updated_at" TIMESTAMP,
+    "updated_by" TEXT,
+    "deleted_at" TIMESTAMP,
+    "deleted_by" TEXT,
+    "activity_log" TEXT,
+    UNIQUE("code")
+);
+CREATE TABLE IF NOT EXISTS "party_identifier_type" (
+    "party_identifier_type_id" INTEGER PRIMARY KEY AUTOINCREMENT,
+    "code" TEXT /* UNIQUE COLUMN */ NOT NULL,
+    "value" TEXT NOT NULL,
+    "created_at" TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    "created_by" TEXT DEFAULT 'UNKNOWN',
+    "updated_at" TIMESTAMP,
+    "updated_by" TEXT,
+    "deleted_at" TIMESTAMP,
+    "deleted_by" TEXT,
+    "activity_log" TEXT,
+    UNIQUE("code")
+);
+CREATE TABLE IF NOT EXISTS "person_type" (
+    "person_type_id" INTEGER PRIMARY KEY AUTOINCREMENT,
+    "code" TEXT /* UNIQUE COLUMN */ NOT NULL,
+    "value" TEXT NOT NULL,
+    "created_at" TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    "created_by" TEXT DEFAULT 'UNKNOWN',
+    "updated_at" TIMESTAMP,
+    "updated_by" TEXT,
+    "deleted_at" TIMESTAMP,
+    "deleted_by" TEXT,
+    "activity_log" TEXT,
+    UNIQUE("code")
+);
+CREATE TABLE IF NOT EXISTS "contact_type" (
+    "contact_type_id" INTEGER PRIMARY KEY AUTOINCREMENT,
+    "code" TEXT /* UNIQUE COLUMN */ NOT NULL,
+    "value" TEXT NOT NULL,
+    "created_at" TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    "created_by" TEXT DEFAULT 'UNKNOWN',
+    "updated_at" TIMESTAMP,
+    "updated_by" TEXT,
+    "deleted_at" TIMESTAMP,
+    "deleted_by" TEXT,
+    "activity_log" TEXT,
+    UNIQUE("code")
+);
 CREATE TABLE IF NOT EXISTS "organization_role_type" (
     "organization_role_type_id" INTEGER PRIMARY KEY AUTOINCREMENT,
     "code" TEXT /* UNIQUE COLUMN */ NOT NULL,
@@ -364,7 +396,7 @@ CREATE TABLE IF NOT EXISTS "party" (
 CREATE TABLE IF NOT EXISTS "party_identifier" (
     "party_identifier_id" INTEGER PRIMARY KEY AUTOINCREMENT,
     "identifier_number" TEXT NOT NULL,
-    "party_identifier_type_id" TEXT NOT NULL,
+    "party_identifier_type_id" INTEGER NOT NULL,
     "party_id" INTEGER NOT NULL,
     "created_at" TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     "created_by" TEXT DEFAULT 'UNKNOWN',
@@ -373,13 +405,13 @@ CREATE TABLE IF NOT EXISTS "party_identifier" (
     "deleted_at" TIMESTAMP,
     "deleted_by" TEXT,
     "activity_log" TEXT,
-    FOREIGN KEY("party_identifier_type_id") REFERENCES "party_identifier_type"("code"),
+    FOREIGN KEY("party_identifier_type_id") REFERENCES "party_identifier_type"("party_identifier_type_id"),
     FOREIGN KEY("party_id") REFERENCES "party"("party_id")
 );
 CREATE TABLE IF NOT EXISTS "person" (
     "person_id" INTEGER PRIMARY KEY AUTOINCREMENT,
     "party_id" INTEGER NOT NULL,
-    "person_type_id" TEXT NOT NULL,
+    "person_type_id" INTEGER NOT NULL,
     "person_first_name" TEXT NOT NULL,
     "person_last_name" TEXT NOT NULL,
     "honorific_prefix" TEXT,
@@ -392,14 +424,14 @@ CREATE TABLE IF NOT EXISTS "person" (
     "deleted_by" TEXT,
     "activity_log" TEXT,
     FOREIGN KEY("party_id") REFERENCES "party"("party_id"),
-    FOREIGN KEY("person_type_id") REFERENCES "person_type"("code")
+    FOREIGN KEY("person_type_id") REFERENCES "person_type"("person_type_id")
 );
 CREATE TABLE IF NOT EXISTS "party_relation" (
     "party_relation_id" INTEGER PRIMARY KEY AUTOINCREMENT,
     "party_id" INTEGER NOT NULL,
     "related_party_id" INTEGER NOT NULL,
     "relation_type_id" TEXT NOT NULL,
-    "party_role_id" TEXT,
+    "party_role_id" INTEGER,
     "created_at" TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     "created_by" TEXT DEFAULT 'UNKNOWN',
     "updated_at" TIMESTAMP,
@@ -410,7 +442,7 @@ CREATE TABLE IF NOT EXISTS "party_relation" (
     FOREIGN KEY("party_id") REFERENCES "party"("party_id"),
     FOREIGN KEY("related_party_id") REFERENCES "party"("party_id"),
     FOREIGN KEY("relation_type_id") REFERENCES "party_relation_type"("code"),
-    FOREIGN KEY("party_role_id") REFERENCES "party_role_type"("code")
+    FOREIGN KEY("party_role_id") REFERENCES "party_role"("party_role_id")
 );
 CREATE TABLE IF NOT EXISTS "organization" (
     "organization_id" INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -445,7 +477,7 @@ CREATE TABLE IF NOT EXISTS "organization_role" (
 );
 CREATE TABLE IF NOT EXISTS "contact_electronic" (
     "contact_electronic_id" INTEGER PRIMARY KEY AUTOINCREMENT,
-    "contact_type_id" TEXT NOT NULL,
+    "contact_type_id" INTEGER NOT NULL,
     "party_id" INTEGER NOT NULL,
     "electronics_details" TEXT NOT NULL,
     "created_at" TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
@@ -455,12 +487,12 @@ CREATE TABLE IF NOT EXISTS "contact_electronic" (
     "deleted_at" TIMESTAMP,
     "deleted_by" TEXT,
     "activity_log" TEXT,
-    FOREIGN KEY("contact_type_id") REFERENCES "contact_type"("code"),
+    FOREIGN KEY("contact_type_id") REFERENCES "contact_type"("contact_type_id"),
     FOREIGN KEY("party_id") REFERENCES "party"("party_id")
 );
 CREATE TABLE IF NOT EXISTS "contact_land" (
     "contact_land_id" INTEGER PRIMARY KEY AUTOINCREMENT,
-    "contact_type_id" TEXT NOT NULL,
+    "contact_type_id" INTEGER NOT NULL,
     "party_id" INTEGER NOT NULL,
     "address_line1" TEXT NOT NULL,
     "address_line2" TEXT NOT NULL,
@@ -475,7 +507,7 @@ CREATE TABLE IF NOT EXISTS "contact_land" (
     "deleted_at" TIMESTAMP,
     "deleted_by" TEXT,
     "activity_log" TEXT,
-    FOREIGN KEY("contact_type_id") REFERENCES "contact_type"("code"),
+    FOREIGN KEY("contact_type_id") REFERENCES "contact_type"("contact_type_id"),
     FOREIGN KEY("party_id") REFERENCES "party"("party_id")
 );
 CREATE TABLE IF NOT EXISTS "asset" (
@@ -1329,8 +1361,6 @@ INSERT INTO "execution_context" ("code", "value") VALUES ('SANDBOX', 'sandbox');
 INSERT INTO "execution_context" ("code", "value") VALUES ('EXPERIMENTAL', 'experimental');
 INSERT INTO "party_type" ("code", "value") VALUES ('PERSON', 'Person');
 INSERT INTO "party_type" ("code", "value") VALUES ('ORGANIZATION', 'Organization');
-INSERT INTO "party_role_type" ("code", "value") VALUES ('CUSTOMER', 'Customer');
-INSERT INTO "party_role_type" ("code", "value") VALUES ('VENDOR', 'Vendor');
 INSERT INTO "contract_status" ("code", "value") VALUES ('ACTIVE', 'Active');
 INSERT INTO "contract_status" ("code", "value") VALUES ('AWAITING_APPROVAL', 'Awaiting Approval');
 INSERT INTO "contract_status" ("code", "value") VALUES ('AWAITING_APPROVAL_FOR_RENEWAL', 'Awaiting Approval For Renewal');
@@ -1564,17 +1594,6 @@ INSERT INTO "audit_status" ("code", "value") VALUES ('ACCEPTED', 'Accepted');
 INSERT INTO "party_relation_type" ("code", "value") VALUES ('PERSON_TO_PERSON', 'Person To Person');
 INSERT INTO "party_relation_type" ("code", "value") VALUES ('ORGANIZATION_TO_PERSON', 'Organization To Person');
 INSERT INTO "party_relation_type" ("code", "value") VALUES ('ORGANIZATION_TO_ORGANIZATION', 'Organization To Organization');
-INSERT INTO "party_identifier_type" ("code", "value") VALUES ('UUID', 'UUID');
-INSERT INTO "party_identifier_type" ("code", "value") VALUES ('DRIVING_LICENSE', 'Driving License');
-INSERT INTO "party_identifier_type" ("code", "value") VALUES ('PASSPORT', 'Passport');
-INSERT INTO "person_type" ("code", "value") VALUES ('INDIVIDUAL', 'Individual');
-INSERT INTO "person_type" ("code", "value") VALUES ('PROFESSIONAL', 'Professional');
-INSERT INTO "contact_type" ("code", "value") VALUES ('HOME_ADDRESS', 'Home Address');
-INSERT INTO "contact_type" ("code", "value") VALUES ('OFFICIAL_ADDRESS', 'Official Address');
-INSERT INTO "contact_type" ("code", "value") VALUES ('MOBILE_PHONE_NUMBER', 'Mobile Phone Number');
-INSERT INTO "contact_type" ("code", "value") VALUES ('LAND_PHONE_NUMBER', 'Land Phone Number');
-INSERT INTO "contact_type" ("code", "value") VALUES ('OFFICIAL_EMAIL', 'Official Email');
-INSERT INTO "contact_type" ("code", "value") VALUES ('PERSONAL_EMAIL', 'Personal Email');
 INSERT INTO "training_subject" ("code", "value") VALUES ('HIPAA', 'HIPAA');
 INSERT INTO "training_subject" ("code", "value") VALUES ('CYBER_SECURITY', 'Cyber Security');
 INSERT INTO "training_subject" ("code", "value") VALUES ('OBSERVABILITY_OPEN_TELEMETRY', 'Observability Open Telemetry');
@@ -1671,6 +1690,27 @@ INSERT INTO "incident_status" ("code", "value") VALUES ('SUSPENDED', 'Suspended'
 INSERT INTO "incident_status" ("code", "value") VALUES ('WORK_IN_PROGRESS', 'Work In Progress');
 INSERT INTO "asset_risk_type" ("code", "value") VALUES ('SECURITY', 'Security');
 
+INSERT INTO "party_role" ("code", "value", "created_by", "updated_at", "updated_by", "deleted_at", "deleted_by", "activity_log")
+       VALUES ('CUSTOMER', 'Customer', NULL, NULL, NULL, NULL, NULL, NULL),
+              ('VENDOR', 'Vendor', NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO "party_identifier_type" ("code", "value", "created_by", "updated_at", "updated_by", "deleted_at", "deleted_by", "activity_log")
+       VALUES ('UUID', 'UUID', NULL, NULL, NULL, NULL, NULL, NULL),
+              ('DRIVING_LICENSE', 'Driving License', NULL, NULL, NULL, NULL, NULL, NULL),
+              ('PASSPORT', 'Passport', NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO "person_type" ("code", "value", "created_by", "updated_at", "updated_by", "deleted_at", "deleted_by", "activity_log")
+       VALUES ('INDIVIDUAL', 'Individual', NULL, NULL, NULL, NULL, NULL, NULL),
+              ('PROFESSIONAL', 'Professional', NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO "contact_type" ("code", "value", "created_by", "updated_at", "updated_by", "deleted_at", "deleted_by", "activity_log")
+       VALUES ('HOME_ADDRESS', 'Home Address', NULL, NULL, NULL, NULL, NULL, NULL),
+              ('OFFICIAL_ADDRESS', 'Official Address', NULL, NULL, NULL, NULL, NULL, NULL),
+              ('MOBILE_PHONE_NUMBER', 'Mobile Phone Number', NULL, NULL, NULL, NULL, NULL, NULL),
+              ('LAND_PHONE_NUMBER', 'Land Phone Number', NULL, NULL, NULL, NULL, NULL, NULL),
+              ('OFFICIAL_EMAIL', 'Official Email', NULL, NULL, NULL, NULL, NULL, NULL),
+              ('PERSONAL_EMAIL', 'Personal Email', NULL, NULL, NULL, NULL, NULL, NULL);
+
 INSERT INTO "organization_role_type" ("code", "value", "created_by", "updated_at", "updated_by", "deleted_at", "deleted_by", "activity_log")
        VALUES ('PROJECT_MANAGER_TECHNOLOGY', 'Project Manager Technology', NULL, NULL, NULL, NULL, NULL, NULL),
               ('PROJECT_MANAGER_QUALITY', 'Project Manager Quality', NULL, NULL, NULL, NULL, NULL, NULL),
@@ -1692,40 +1732,39 @@ INSERT INTO "organization_role_type" ("code", "value", "created_by", "updated_at
 ;
 INSERT INTO "party" ("party_type_id", "party_name", "created_by", "updated_at", "updated_by", "deleted_at", "deleted_by", "activity_log") VALUES ('ORGANIZATION', 'Orgnization Name', NULL, NULL, NULL, NULL, NULL, NULL);
 INSERT INTO "organization" ("party_id", "name", "license", "registration_date", "created_by", "updated_at", "updated_by", "deleted_at", "deleted_by", "activity_log") VALUES ((SELECT "party_id" FROM "party" WHERE "party_type_id" = 'ORGANIZATION' AND "party_name" = 'Orgnization Name'), 'Orgnization Name', 'XXXX-XXXXX-XXXX', '2010-01-15', NULL, NULL, NULL, NULL, NULL, NULL);
-INSERT INTO "contact_electronic" ("contact_type_id", "party_id", "electronics_details", "created_by", "updated_at", "updated_by", "deleted_at", "deleted_by", "activity_log") VALUES ('OFFICIAL_EMAIL', (SELECT "party_id" FROM "party" WHERE "party_type_id" = 'ORGANIZATION' AND "party_name" = 'Orgnization Name'), 'orgnization@email.com', NULL, NULL, NULL, NULL, NULL, NULL);
-INSERT INTO "contact_electronic" ("contact_type_id", "party_id", "electronics_details", "created_by", "updated_at", "updated_by", "deleted_at", "deleted_by", "activity_log") VALUES ('LAND_PHONE_NUMBER', (SELECT "party_id" FROM "party" WHERE "party_type_id" = 'ORGANIZATION' AND "party_name" = 'Orgnization Name'), '0523 852 9945', NULL, NULL, NULL, NULL, NULL, NULL);
+INSERT INTO "contact_electronic" ("contact_type_id", "party_id", "electronics_details", "created_by", "updated_at", "updated_by", "deleted_at", "deleted_by", "activity_log") VALUES ((SELECT "contact_type_id" FROM "contact_type" WHERE "code" = 'OFFICIAL_EMAIL'), (SELECT "party_id" FROM "party" WHERE "party_type_id" = 'ORGANIZATION' AND "party_name" = 'Orgnization Name'), 'orgnization@email.com', NULL, NULL, NULL, NULL, NULL, NULL);
+INSERT INTO "contact_electronic" ("contact_type_id", "party_id", "electronics_details", "created_by", "updated_at", "updated_by", "deleted_at", "deleted_by", "activity_log") VALUES ((SELECT "contact_type_id" FROM "contact_type" WHERE "code" = 'LAND_PHONE_NUMBER'), (SELECT "party_id" FROM "party" WHERE "party_type_id" = 'ORGANIZATION' AND "party_name" = 'Orgnization Name'), '0523 852 9945', NULL, NULL, NULL, NULL, NULL, NULL);
 ;
-INSERT INTO "contact_land" ("contact_type_id", "party_id", "address_line1", "address_line2", "address_zip", "address_city", "address_state", "address_country", "created_by", "updated_at", "updated_by", "deleted_at", "deleted_by", "activity_log") VALUES ('OFFICIAL_ADDRESS', (SELECT "party_id" FROM "party" WHERE "party_type_id" = 'ORGANIZATION' AND "party_name" = 'Orgnization Name'), 'Address line 1', 'Address line 2', '', 'City', 'State', 'Country', NULL, NULL, NULL, NULL, NULL, NULL);
+INSERT INTO "contact_land" ("contact_type_id", "party_id", "address_line1", "address_line2", "address_zip", "address_city", "address_state", "address_country", "created_by", "updated_at", "updated_by", "deleted_at", "deleted_by", "activity_log") VALUES ((SELECT "contact_type_id" FROM "contact_type" WHERE "code" = 'OFFICIAL_ADDRESS'), (SELECT "party_id" FROM "party" WHERE "party_type_id" = 'ORGANIZATION' AND "party_name" = 'Orgnization Name'), 'Address line 1', 'Address line 2', '', 'City', 'State', 'Country', NULL, NULL, NULL, NULL, NULL, NULL);
 INSERT INTO "party" ("party_type_id", "party_name", "created_by", "updated_at", "updated_by", "deleted_at", "deleted_by", "activity_log") VALUES ('PERSON', 'First Name Last Name', NULL, NULL, NULL, NULL, NULL, NULL);
-INSERT INTO "person" ("party_id", "person_type_id", "person_first_name", "person_last_name", "honorific_prefix", "honorific_suffix", "created_by", "updated_at", "updated_by", "deleted_at", "deleted_by", "activity_log") VALUES ((SELECT "party_id" FROM "party" WHERE "party_type_id" = 'PERSON' AND "party_name" = 'First Name Last Name'), 'INDIVIDUAL', 'First Name', 'Last Name', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
-INSERT INTO "contact_electronic" ("contact_type_id", "party_id", "electronics_details", "created_by", "updated_at", "updated_by", "deleted_at", "deleted_by", "activity_log") VALUES ('OFFICIAL_EMAIL', (SELECT "party_id" FROM "party" WHERE "party_type_id" = 'PERSON' AND "party_name" = 'First Name Last Name'), 'person@org.com', NULL, NULL, NULL, NULL, NULL, NULL);
-INSERT INTO "contact_electronic" ("contact_type_id", "party_id", "electronics_details", "created_by", "updated_at", "updated_by", "deleted_at", "deleted_by", "activity_log") VALUES ('MOBILE_PHONE_NUMBER', (SELECT "party_id" FROM "party" WHERE "party_type_id" = 'PERSON' AND "party_name" = 'First Name Last Name'), '+911234567890', NULL, NULL, NULL, NULL, NULL, NULL);
+INSERT INTO "person" ("party_id", "person_type_id", "person_first_name", "person_last_name", "honorific_prefix", "honorific_suffix", "created_by", "updated_at", "updated_by", "deleted_at", "deleted_by", "activity_log") VALUES ((SELECT "party_id" FROM "party" WHERE "party_type_id" = 'PERSON' AND "party_name" = 'First Name Last Name'), (SELECT "person_type_id" FROM "person_type" WHERE "code" = 'INDIVIDUAL'), 'First Name', 'Last Name', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+INSERT INTO "contact_electronic" ("contact_type_id", "party_id", "electronics_details", "created_by", "updated_at", "updated_by", "deleted_at", "deleted_by", "activity_log") VALUES ((SELECT "contact_type_id" FROM "contact_type" WHERE "code" = 'OFFICIAL_EMAIL'), (SELECT "party_id" FROM "party" WHERE "party_type_id" = 'PERSON' AND "party_name" = 'First Name Last Name'), 'person@org.com', NULL, NULL, NULL, NULL, NULL, NULL);
+INSERT INTO "contact_electronic" ("contact_type_id", "party_id", "electronics_details", "created_by", "updated_at", "updated_by", "deleted_at", "deleted_by", "activity_log") VALUES ((SELECT "contact_type_id" FROM "contact_type" WHERE "code" = 'MOBILE_PHONE_NUMBER'), (SELECT "party_id" FROM "party" WHERE "party_type_id" = 'PERSON' AND "party_name" = 'First Name Last Name'), '+911234567890', NULL, NULL, NULL, NULL, NULL, NULL);
 ;
-INSERT INTO "contact_land" ("contact_type_id", "party_id", "address_line1", "address_line2", "address_zip", "address_city", "address_state", "address_country", "created_by", "updated_at", "updated_by", "deleted_at", "deleted_by", "activity_log") VALUES ('OFFICIAL_ADDRESS', (SELECT "party_id" FROM "party" WHERE "party_type_id" = 'PERSON' AND "party_name" = 'First Name Last Name'), 'Address line 1', 'Address line 2', '', 'City', 'State', 'Country', NULL, NULL, NULL, NULL, NULL, NULL);
+INSERT INTO "contact_land" ("contact_type_id", "party_id", "address_line1", "address_line2", "address_zip", "address_city", "address_state", "address_country", "created_by", "updated_at", "updated_by", "deleted_at", "deleted_by", "activity_log") VALUES ((SELECT "contact_type_id" FROM "contact_type" WHERE "code" = 'OFFICIAL_ADDRESS'), (SELECT "party_id" FROM "party" WHERE "party_type_id" = 'PERSON' AND "party_name" = 'First Name Last Name'), 'Address line 1', 'Address line 2', '', 'City', 'State', 'Country', NULL, NULL, NULL, NULL, NULL, NULL);
 ;
-INSERT INTO "party_relation" ("party_id", "related_party_id", "relation_type_id", "party_role_id", "created_by", "updated_at", "updated_by", "deleted_at", "deleted_by", "activity_log") VALUES ((SELECT "party_id" FROM "party" WHERE "party_type_id" = 'PERSON' AND "party_name" = 'First Name Last Name'), (SELECT "party_id" FROM "party" WHERE "party_type_id" = 'ORGANIZATION' AND "party_name" = 'Orgnization Name'), 'ORGANIZATION_TO_PERSON', 'VENDOR', NULL, NULL, NULL, NULL, NULL, NULL);
-INSERT INTO "organization_role" ("person_id", "organization_id", "organization_role_type_id", "created_by", "updated_at", "updated_by", "deleted_at", "deleted_by", "activity_log") VALUES ((SELECT "person_id" FROM "person" WHERE "party_id" = (SELECT "party_id" FROM "party" WHERE "party_type_id" = 'PERSON' AND "party_name" = 'First Name Last Name') AND "person_type_id" = 'INDIVIDUAL' AND "person_first_name" = 'First Name' AND "person_last_name" = 'Last Name'), (SELECT "organization_id" FROM "organization" WHERE "name" = 'Orgnization Name' AND "license" = 'XXXX-XXXXX-XXXX'), (SELECT "organization_role_type_id" FROM "organization_role_type" WHERE "code" = 'LEAD_SOFTWARE_ENGINEER'), NULL, NULL, NULL, NULL, NULL, NULL);
-INSERT INTO "person_skill" ("person_id", "skill_nature_id", "skill_id", "proficiency_scale_id", "created_by", "updated_at", "updated_by", "deleted_at", "deleted_by", "activity_log") VALUES ((SELECT "person_id" FROM "person" WHERE "party_id" = (SELECT "party_id" FROM "party" WHERE "party_type_id" = 'PERSON' AND "party_name" = 'First Name Last Name') AND "person_type_id" = 'INDIVIDUAL' AND "person_first_name" = 'First Name' AND "person_last_name" = 'Last Name'), 'SOFTWARE', 'REACTJS', 'INTERMEDIATE', NULL, NULL, NULL, NULL, NULL, NULL);
-INSERT INTO "person_skill" ("person_id", "skill_nature_id", "skill_id", "proficiency_scale_id", "created_by", "updated_at", "updated_by", "deleted_at", "deleted_by", "activity_log") VALUES ((SELECT "person_id" FROM "person" WHERE "party_id" = (SELECT "party_id" FROM "party" WHERE "party_type_id" = 'PERSON' AND "party_name" = 'First Name Last Name') AND "person_type_id" = 'INDIVIDUAL' AND "person_first_name" = 'First Name' AND "person_last_name" = 'Last Name'), 'SOFTWARE', 'JAVASCRIPT', 'ADVANCED', NULL, NULL, NULL, NULL, NULL, NULL);
-INSERT INTO "person_skill" ("person_id", "skill_nature_id", "skill_id", "proficiency_scale_id", "created_by", "updated_at", "updated_by", "deleted_at", "deleted_by", "activity_log") VALUES ((SELECT "person_id" FROM "person" WHERE "party_id" = (SELECT "party_id" FROM "party" WHERE "party_type_id" = 'PERSON' AND "party_name" = 'First Name Last Name') AND "person_type_id" = 'INDIVIDUAL' AND "person_first_name" = 'First Name' AND "person_last_name" = 'Last Name'), 'SOFTWARE', 'HUGO', 'FUNDAMENTAL_AWARENESS', NULL, NULL, NULL, NULL, NULL, NULL);
-INSERT INTO "person_skill" ("person_id", "skill_nature_id", "skill_id", "proficiency_scale_id", "created_by", "updated_at", "updated_by", "deleted_at", "deleted_by", "activity_log") VALUES ((SELECT "person_id" FROM "person" WHERE "party_id" = (SELECT "party_id" FROM "party" WHERE "party_type_id" = 'PERSON' AND "party_name" = 'First Name Last Name') AND "person_type_id" = 'INDIVIDUAL' AND "person_first_name" = 'First Name' AND "person_last_name" = 'Last Name'), 'SOFTWARE', 'DENO', 'INTERMEDIATE', NULL, NULL, NULL, NULL, NULL, NULL);
-INSERT INTO "person_skill" ("person_id", "skill_nature_id", "skill_id", "proficiency_scale_id", "created_by", "updated_at", "updated_by", "deleted_at", "deleted_by", "activity_log") VALUES ((SELECT "person_id" FROM "person" WHERE "party_id" = (SELECT "party_id" FROM "party" WHERE "party_type_id" = 'PERSON' AND "party_name" = 'First Name Last Name') AND "person_type_id" = 'INDIVIDUAL' AND "person_first_name" = 'First Name' AND "person_last_name" = 'Last Name'), 'SOFTWARE', 'ANGULAR', 'INTERMEDIATE', NULL, NULL, NULL, NULL, NULL, NULL);
-INSERT INTO "person_skill" ("person_id", "skill_nature_id", "skill_id", "proficiency_scale_id", "created_by", "updated_at", "updated_by", "deleted_at", "deleted_by", "activity_log") VALUES ((SELECT "person_id" FROM "person" WHERE "party_id" = (SELECT "party_id" FROM "party" WHERE "party_type_id" = 'PERSON' AND "party_name" = 'First Name Last Name') AND "person_type_id" = 'INDIVIDUAL' AND "person_first_name" = 'First Name' AND "person_last_name" = 'Last Name'), 'SOFTWARE', 'TYPESCRIPT', 'INTERMEDIATE', NULL, NULL, NULL, NULL, NULL, NULL);
-INSERT INTO "person_skill" ("person_id", "skill_nature_id", "skill_id", "proficiency_scale_id", "created_by", "updated_at", "updated_by", "deleted_at", "deleted_by", "activity_log") VALUES ((SELECT "person_id" FROM "person" WHERE "party_id" = (SELECT "party_id" FROM "party" WHERE "party_type_id" = 'PERSON' AND "party_name" = 'First Name Last Name') AND "person_type_id" = 'INDIVIDUAL' AND "person_first_name" = 'First Name' AND "person_last_name" = 'Last Name'), 'SOFTWARE', 'POSTGRESQL', 'INTERMEDIATE', NULL, NULL, NULL, NULL, NULL, NULL);
-INSERT INTO "person_skill" ("person_id", "skill_nature_id", "skill_id", "proficiency_scale_id", "created_by", "updated_at", "updated_by", "deleted_at", "deleted_by", "activity_log") VALUES ((SELECT "person_id" FROM "person" WHERE "party_id" = (SELECT "party_id" FROM "party" WHERE "party_type_id" = 'PERSON' AND "party_name" = 'First Name Last Name') AND "person_type_id" = 'INDIVIDUAL' AND "person_first_name" = 'First Name' AND "person_last_name" = 'Last Name'), 'SOFTWARE', 'MYSQL', 'INTERMEDIATE', NULL, NULL, NULL, NULL, NULL, NULL);
-INSERT INTO "person_skill" ("person_id", "skill_nature_id", "skill_id", "proficiency_scale_id", "created_by", "updated_at", "updated_by", "deleted_at", "deleted_by", "activity_log") VALUES ((SELECT "person_id" FROM "person" WHERE "party_id" = (SELECT "party_id" FROM "party" WHERE "party_type_id" = 'PERSON' AND "party_name" = 'First Name Last Name') AND "person_type_id" = 'INDIVIDUAL' AND "person_first_name" = 'First Name' AND "person_last_name" = 'Last Name'), 'SOFTWARE', 'PHP', 'INTERMEDIATE', NULL, NULL, NULL, NULL, NULL, NULL);
-INSERT INTO "person_skill" ("person_id", "skill_nature_id", "skill_id", "proficiency_scale_id", "created_by", "updated_at", "updated_by", "deleted_at", "deleted_by", "activity_log") VALUES ((SELECT "person_id" FROM "person" WHERE "party_id" = (SELECT "party_id" FROM "party" WHERE "party_type_id" = 'PERSON' AND "party_name" = 'First Name Last Name') AND "person_type_id" = 'INDIVIDUAL' AND "person_first_name" = 'First Name' AND "person_last_name" = 'Last Name'), 'SOFTWARE', 'PYTHON', 'FUNDAMENTAL_AWARENESS', NULL, NULL, NULL, NULL, NULL, NULL);
-INSERT INTO "person_skill" ("person_id", "skill_nature_id", "skill_id", "proficiency_scale_id", "created_by", "updated_at", "updated_by", "deleted_at", "deleted_by", "activity_log") VALUES ((SELECT "person_id" FROM "person" WHERE "party_id" = (SELECT "party_id" FROM "party" WHERE "party_type_id" = 'PERSON' AND "party_name" = 'First Name Last Name') AND "person_type_id" = 'INDIVIDUAL' AND "person_first_name" = 'First Name' AND "person_last_name" = 'Last Name'), 'SOFTWARE', 'DOT_NET', 'NA', NULL, NULL, NULL, NULL, NULL, NULL);
-INSERT INTO "person_skill" ("person_id", "skill_nature_id", "skill_id", "proficiency_scale_id", "created_by", "updated_at", "updated_by", "deleted_at", "deleted_by", "activity_log") VALUES ((SELECT "person_id" FROM "person" WHERE "party_id" = (SELECT "party_id" FROM "party" WHERE "party_type_id" = 'PERSON' AND "party_name" = 'First Name Last Name') AND "person_type_id" = 'INDIVIDUAL' AND "person_first_name" = 'First Name' AND "person_last_name" = 'Last Name'), 'SOFTWARE', 'ORACLE', 'NA', NULL, NULL, NULL, NULL, NULL, NULL);
-INSERT INTO "person_skill" ("person_id", "skill_nature_id", "skill_id", "proficiency_scale_id", "created_by", "updated_at", "updated_by", "deleted_at", "deleted_by", "activity_log") VALUES ((SELECT "person_id" FROM "person" WHERE "party_id" = (SELECT "party_id" FROM "party" WHERE "party_type_id" = 'PERSON' AND "party_name" = 'First Name Last Name') AND "person_type_id" = 'INDIVIDUAL' AND "person_first_name" = 'First Name' AND "person_last_name" = 'Last Name'), 'SOFTWARE', 'JAVA', 'FUNDAMENTAL_AWARENESS', NULL, NULL, NULL, NULL, NULL, NULL);
-INSERT INTO "person_skill" ("person_id", "skill_nature_id", "skill_id", "proficiency_scale_id", "created_by", "updated_at", "updated_by", "deleted_at", "deleted_by", "activity_log") VALUES ((SELECT "person_id" FROM "person" WHERE "party_id" = (SELECT "party_id" FROM "party" WHERE "party_type_id" = 'PERSON' AND "party_name" = 'First Name Last Name') AND "person_type_id" = 'INDIVIDUAL' AND "person_first_name" = 'First Name' AND "person_last_name" = 'Last Name'), 'SOFTWARE', 'JQUERY', 'ADVANCED', NULL, NULL, NULL, NULL, NULL, NULL);
-INSERT INTO "person_skill" ("person_id", "skill_nature_id", "skill_id", "proficiency_scale_id", "created_by", "updated_at", "updated_by", "deleted_at", "deleted_by", "activity_log") VALUES ((SELECT "person_id" FROM "person" WHERE "party_id" = (SELECT "party_id" FROM "party" WHERE "party_type_id" = 'PERSON' AND "party_name" = 'First Name Last Name') AND "person_type_id" = 'INDIVIDUAL' AND "person_first_name" = 'First Name' AND "person_last_name" = 'Last Name'), 'SOFTWARE', 'OSQUERY', 'FUNDAMENTAL_AWARENESS', NULL, NULL, NULL, NULL, NULL, NULL);
-INSERT INTO "organization_role_type" ("code", "value", "created_by", "updated_at", "updated_by", "deleted_at", "deleted_by", "activity_log") VALUES ('LEAD_SOFTWARE_ENGINEER', 'Lead Software Engineer', NULL, NULL, NULL, NULL, NULL, NULL);
-INSERT INTO "awareness_training" ("training_subject_id", "person_id", "organization_id", "training_status_id", "attended_date", "created_by", "updated_at", "updated_by", "deleted_at", "deleted_by", "activity_log") VALUES ('HIPAA', (SELECT "person_id" FROM "person" WHERE "party_id" = (SELECT "party_id" FROM "party" WHERE "party_type_id" = 'PERSON' AND "party_name" = 'First Name Last Name') AND "person_type_id" = 'INDIVIDUAL' AND "person_first_name" = 'First Name' AND "person_last_name" = 'Last Name'), (SELECT "organization_id" FROM "organization" WHERE "name" = 'Orgnization Name' AND "license" = 'XXXX-XXXXX-XXXX'), 'YES', '2022-02-21', NULL, NULL, NULL, NULL, NULL, NULL);
-INSERT INTO "security_incident_response_team" ("training_subject_id", "person_id", "organization_id", "training_status_id", "attended_date", "created_by", "updated_at", "updated_by", "deleted_at", "deleted_by", "activity_log") VALUES (NULL, (SELECT "person_id" FROM "person" WHERE "party_id" = (SELECT "party_id" FROM "party" WHERE "party_type_id" = 'PERSON' AND "party_name" = 'First Name Last Name') AND "person_type_id" = 'INDIVIDUAL' AND "person_first_name" = 'First Name' AND "person_last_name" = 'Last Name'), (SELECT "organization_id" FROM "organization" WHERE "name" = 'Orgnization Name' AND "license" = 'XXXX-XXXXX-XXXX'), NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
-INSERT INTO "rating" ("author_id", "rating_given_to_id", "rating_value_id", "best_rating_id", "rating_explanation", "review_aspect", "worst_rating_id", "created_by", "updated_at", "updated_by", "deleted_at", "deleted_by", "activity_log") VALUES ((SELECT "person_id" FROM "person" WHERE "party_id" = (SELECT "party_id" FROM "party" WHERE "party_type_id" = 'PERSON' AND "party_name" = 'First Name Last Name') AND "person_type_id" = 'INDIVIDUAL' AND "person_first_name" = 'First Name' AND "person_last_name" = 'Last Name'), (SELECT "organization_id" FROM "organization" WHERE "name" = 'Orgnization Name' AND "license" = 'XXXX-XXXXX-XXXX'), 'FOUR', 'FIVE', 'Good Service', 'Satisfied', 'THREE', NULL, NULL, NULL, NULL, NULL, NULL);
+INSERT INTO "party_relation" ("party_id", "related_party_id", "relation_type_id", "party_role_id", "created_by", "updated_at", "updated_by", "deleted_at", "deleted_by", "activity_log") VALUES ((SELECT "party_id" FROM "party" WHERE "party_type_id" = 'PERSON' AND "party_name" = 'First Name Last Name'), (SELECT "party_id" FROM "party" WHERE "party_type_id" = 'ORGANIZATION' AND "party_name" = 'Orgnization Name'), 'ORGANIZATION_TO_PERSON', (SELECT "party_role_id" FROM "party_role" WHERE "code" = 'VENDOR'), NULL, NULL, NULL, NULL, NULL, NULL);
+INSERT INTO "organization_role" ("person_id", "organization_id", "organization_role_type_id", "created_by", "updated_at", "updated_by", "deleted_at", "deleted_by", "activity_log") VALUES ((SELECT "person_id" FROM "person" WHERE "party_id" = (SELECT "party_id" FROM "party" WHERE "party_type_id" = 'PERSON' AND "party_name" = 'First Name Last Name') AND "person_type_id" = (SELECT "person_type_id" FROM "person_type" WHERE "code" = 'INDIVIDUAL') AND "person_first_name" = 'First Name' AND "person_last_name" = 'Last Name'), (SELECT "organization_id" FROM "organization" WHERE "name" = 'Orgnization Name' AND "license" = 'XXXX-XXXXX-XXXX'), (SELECT "organization_role_type_id" FROM "organization_role_type" WHERE "code" = 'LEAD_SOFTWARE_ENGINEER'), NULL, NULL, NULL, NULL, NULL, NULL);
+INSERT INTO "person_skill" ("person_id", "skill_nature_id", "skill_id", "proficiency_scale_id", "created_by", "updated_at", "updated_by", "deleted_at", "deleted_by", "activity_log") VALUES ((SELECT "person_id" FROM "person" WHERE "party_id" = (SELECT "party_id" FROM "party" WHERE "party_type_id" = 'PERSON' AND "party_name" = 'First Name Last Name') AND "person_type_id" = (SELECT "person_type_id" FROM "person_type" WHERE "code" = 'INDIVIDUAL') AND "person_first_name" = 'First Name' AND "person_last_name" = 'Last Name'), 'SOFTWARE', 'REACTJS', 'INTERMEDIATE', NULL, NULL, NULL, NULL, NULL, NULL);
+INSERT INTO "person_skill" ("person_id", "skill_nature_id", "skill_id", "proficiency_scale_id", "created_by", "updated_at", "updated_by", "deleted_at", "deleted_by", "activity_log") VALUES ((SELECT "person_id" FROM "person" WHERE "party_id" = (SELECT "party_id" FROM "party" WHERE "party_type_id" = 'PERSON' AND "party_name" = 'First Name Last Name') AND "person_type_id" = (SELECT "person_type_id" FROM "person_type" WHERE "code" = 'INDIVIDUAL') AND "person_first_name" = 'First Name' AND "person_last_name" = 'Last Name'), 'SOFTWARE', 'JAVASCRIPT', 'ADVANCED', NULL, NULL, NULL, NULL, NULL, NULL);
+INSERT INTO "person_skill" ("person_id", "skill_nature_id", "skill_id", "proficiency_scale_id", "created_by", "updated_at", "updated_by", "deleted_at", "deleted_by", "activity_log") VALUES ((SELECT "person_id" FROM "person" WHERE "party_id" = (SELECT "party_id" FROM "party" WHERE "party_type_id" = 'PERSON' AND "party_name" = 'First Name Last Name') AND "person_type_id" = (SELECT "person_type_id" FROM "person_type" WHERE "code" = 'INDIVIDUAL') AND "person_first_name" = 'First Name' AND "person_last_name" = 'Last Name'), 'SOFTWARE', 'HUGO', 'FUNDAMENTAL_AWARENESS', NULL, NULL, NULL, NULL, NULL, NULL);
+INSERT INTO "person_skill" ("person_id", "skill_nature_id", "skill_id", "proficiency_scale_id", "created_by", "updated_at", "updated_by", "deleted_at", "deleted_by", "activity_log") VALUES ((SELECT "person_id" FROM "person" WHERE "party_id" = (SELECT "party_id" FROM "party" WHERE "party_type_id" = 'PERSON' AND "party_name" = 'First Name Last Name') AND "person_type_id" = (SELECT "person_type_id" FROM "person_type" WHERE "code" = 'INDIVIDUAL') AND "person_first_name" = 'First Name' AND "person_last_name" = 'Last Name'), 'SOFTWARE', 'DENO', 'INTERMEDIATE', NULL, NULL, NULL, NULL, NULL, NULL);
+INSERT INTO "person_skill" ("person_id", "skill_nature_id", "skill_id", "proficiency_scale_id", "created_by", "updated_at", "updated_by", "deleted_at", "deleted_by", "activity_log") VALUES ((SELECT "person_id" FROM "person" WHERE "party_id" = (SELECT "party_id" FROM "party" WHERE "party_type_id" = 'PERSON' AND "party_name" = 'First Name Last Name') AND "person_type_id" = (SELECT "person_type_id" FROM "person_type" WHERE "code" = 'INDIVIDUAL') AND "person_first_name" = 'First Name' AND "person_last_name" = 'Last Name'), 'SOFTWARE', 'ANGULAR', 'INTERMEDIATE', NULL, NULL, NULL, NULL, NULL, NULL);
+INSERT INTO "person_skill" ("person_id", "skill_nature_id", "skill_id", "proficiency_scale_id", "created_by", "updated_at", "updated_by", "deleted_at", "deleted_by", "activity_log") VALUES ((SELECT "person_id" FROM "person" WHERE "party_id" = (SELECT "party_id" FROM "party" WHERE "party_type_id" = 'PERSON' AND "party_name" = 'First Name Last Name') AND "person_type_id" = (SELECT "person_type_id" FROM "person_type" WHERE "code" = 'INDIVIDUAL') AND "person_first_name" = 'First Name' AND "person_last_name" = 'Last Name'), 'SOFTWARE', 'TYPESCRIPT', 'INTERMEDIATE', NULL, NULL, NULL, NULL, NULL, NULL);
+INSERT INTO "person_skill" ("person_id", "skill_nature_id", "skill_id", "proficiency_scale_id", "created_by", "updated_at", "updated_by", "deleted_at", "deleted_by", "activity_log") VALUES ((SELECT "person_id" FROM "person" WHERE "party_id" = (SELECT "party_id" FROM "party" WHERE "party_type_id" = 'PERSON' AND "party_name" = 'First Name Last Name') AND "person_type_id" = (SELECT "person_type_id" FROM "person_type" WHERE "code" = 'INDIVIDUAL') AND "person_first_name" = 'First Name' AND "person_last_name" = 'Last Name'), 'SOFTWARE', 'POSTGRESQL', 'INTERMEDIATE', NULL, NULL, NULL, NULL, NULL, NULL);
+INSERT INTO "person_skill" ("person_id", "skill_nature_id", "skill_id", "proficiency_scale_id", "created_by", "updated_at", "updated_by", "deleted_at", "deleted_by", "activity_log") VALUES ((SELECT "person_id" FROM "person" WHERE "party_id" = (SELECT "party_id" FROM "party" WHERE "party_type_id" = 'PERSON' AND "party_name" = 'First Name Last Name') AND "person_type_id" = (SELECT "person_type_id" FROM "person_type" WHERE "code" = 'INDIVIDUAL') AND "person_first_name" = 'First Name' AND "person_last_name" = 'Last Name'), 'SOFTWARE', 'MYSQL', 'INTERMEDIATE', NULL, NULL, NULL, NULL, NULL, NULL);
+INSERT INTO "person_skill" ("person_id", "skill_nature_id", "skill_id", "proficiency_scale_id", "created_by", "updated_at", "updated_by", "deleted_at", "deleted_by", "activity_log") VALUES ((SELECT "person_id" FROM "person" WHERE "party_id" = (SELECT "party_id" FROM "party" WHERE "party_type_id" = 'PERSON' AND "party_name" = 'First Name Last Name') AND "person_type_id" = (SELECT "person_type_id" FROM "person_type" WHERE "code" = 'INDIVIDUAL') AND "person_first_name" = 'First Name' AND "person_last_name" = 'Last Name'), 'SOFTWARE', 'PHP', 'INTERMEDIATE', NULL, NULL, NULL, NULL, NULL, NULL);
+INSERT INTO "person_skill" ("person_id", "skill_nature_id", "skill_id", "proficiency_scale_id", "created_by", "updated_at", "updated_by", "deleted_at", "deleted_by", "activity_log") VALUES ((SELECT "person_id" FROM "person" WHERE "party_id" = (SELECT "party_id" FROM "party" WHERE "party_type_id" = 'PERSON' AND "party_name" = 'First Name Last Name') AND "person_type_id" = (SELECT "person_type_id" FROM "person_type" WHERE "code" = 'INDIVIDUAL') AND "person_first_name" = 'First Name' AND "person_last_name" = 'Last Name'), 'SOFTWARE', 'PYTHON', 'FUNDAMENTAL_AWARENESS', NULL, NULL, NULL, NULL, NULL, NULL);
+INSERT INTO "person_skill" ("person_id", "skill_nature_id", "skill_id", "proficiency_scale_id", "created_by", "updated_at", "updated_by", "deleted_at", "deleted_by", "activity_log") VALUES ((SELECT "person_id" FROM "person" WHERE "party_id" = (SELECT "party_id" FROM "party" WHERE "party_type_id" = 'PERSON' AND "party_name" = 'First Name Last Name') AND "person_type_id" = (SELECT "person_type_id" FROM "person_type" WHERE "code" = 'INDIVIDUAL') AND "person_first_name" = 'First Name' AND "person_last_name" = 'Last Name'), 'SOFTWARE', 'DOT_NET', 'NA', NULL, NULL, NULL, NULL, NULL, NULL);
+INSERT INTO "person_skill" ("person_id", "skill_nature_id", "skill_id", "proficiency_scale_id", "created_by", "updated_at", "updated_by", "deleted_at", "deleted_by", "activity_log") VALUES ((SELECT "person_id" FROM "person" WHERE "party_id" = (SELECT "party_id" FROM "party" WHERE "party_type_id" = 'PERSON' AND "party_name" = 'First Name Last Name') AND "person_type_id" = (SELECT "person_type_id" FROM "person_type" WHERE "code" = 'INDIVIDUAL') AND "person_first_name" = 'First Name' AND "person_last_name" = 'Last Name'), 'SOFTWARE', 'ORACLE', 'NA', NULL, NULL, NULL, NULL, NULL, NULL);
+INSERT INTO "person_skill" ("person_id", "skill_nature_id", "skill_id", "proficiency_scale_id", "created_by", "updated_at", "updated_by", "deleted_at", "deleted_by", "activity_log") VALUES ((SELECT "person_id" FROM "person" WHERE "party_id" = (SELECT "party_id" FROM "party" WHERE "party_type_id" = 'PERSON' AND "party_name" = 'First Name Last Name') AND "person_type_id" = (SELECT "person_type_id" FROM "person_type" WHERE "code" = 'INDIVIDUAL') AND "person_first_name" = 'First Name' AND "person_last_name" = 'Last Name'), 'SOFTWARE', 'JAVA', 'FUNDAMENTAL_AWARENESS', NULL, NULL, NULL, NULL, NULL, NULL);
+INSERT INTO "person_skill" ("person_id", "skill_nature_id", "skill_id", "proficiency_scale_id", "created_by", "updated_at", "updated_by", "deleted_at", "deleted_by", "activity_log") VALUES ((SELECT "person_id" FROM "person" WHERE "party_id" = (SELECT "party_id" FROM "party" WHERE "party_type_id" = 'PERSON' AND "party_name" = 'First Name Last Name') AND "person_type_id" = (SELECT "person_type_id" FROM "person_type" WHERE "code" = 'INDIVIDUAL') AND "person_first_name" = 'First Name' AND "person_last_name" = 'Last Name'), 'SOFTWARE', 'JQUERY', 'ADVANCED', NULL, NULL, NULL, NULL, NULL, NULL);
+INSERT INTO "person_skill" ("person_id", "skill_nature_id", "skill_id", "proficiency_scale_id", "created_by", "updated_at", "updated_by", "deleted_at", "deleted_by", "activity_log") VALUES ((SELECT "person_id" FROM "person" WHERE "party_id" = (SELECT "party_id" FROM "party" WHERE "party_type_id" = 'PERSON' AND "party_name" = 'First Name Last Name') AND "person_type_id" = (SELECT "person_type_id" FROM "person_type" WHERE "code" = 'INDIVIDUAL') AND "person_first_name" = 'First Name' AND "person_last_name" = 'Last Name'), 'SOFTWARE', 'OSQUERY', 'FUNDAMENTAL_AWARENESS', NULL, NULL, NULL, NULL, NULL, NULL);
+INSERT INTO "awareness_training" ("training_subject_id", "person_id", "organization_id", "training_status_id", "attended_date", "created_by", "updated_at", "updated_by", "deleted_at", "deleted_by", "activity_log") VALUES ('HIPAA', (SELECT "person_id" FROM "person" WHERE "party_id" = (SELECT "party_id" FROM "party" WHERE "party_type_id" = 'PERSON' AND "party_name" = 'First Name Last Name') AND "person_type_id" = (SELECT "person_type_id" FROM "person_type" WHERE "code" = 'INDIVIDUAL') AND "person_first_name" = 'First Name' AND "person_last_name" = 'Last Name'), (SELECT "organization_id" FROM "organization" WHERE "name" = 'Orgnization Name' AND "license" = 'XXXX-XXXXX-XXXX'), 'YES', '2022-02-21', NULL, NULL, NULL, NULL, NULL, NULL);
+INSERT INTO "security_incident_response_team" ("training_subject_id", "person_id", "organization_id", "training_status_id", "attended_date", "created_by", "updated_at", "updated_by", "deleted_at", "deleted_by", "activity_log") VALUES (NULL, (SELECT "person_id" FROM "person" WHERE "party_id" = (SELECT "party_id" FROM "party" WHERE "party_type_id" = 'PERSON' AND "party_name" = 'First Name Last Name') AND "person_type_id" = (SELECT "person_type_id" FROM "person_type" WHERE "code" = 'INDIVIDUAL') AND "person_first_name" = 'First Name' AND "person_last_name" = 'Last Name'), (SELECT "organization_id" FROM "organization" WHERE "name" = 'Orgnization Name' AND "license" = 'XXXX-XXXXX-XXXX'), NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+INSERT INTO "rating" ("author_id", "rating_given_to_id", "rating_value_id", "best_rating_id", "rating_explanation", "review_aspect", "worst_rating_id", "created_by", "updated_at", "updated_by", "deleted_at", "deleted_by", "activity_log") VALUES ((SELECT "person_id" FROM "person" WHERE "party_id" = (SELECT "party_id" FROM "party" WHERE "party_type_id" = 'PERSON' AND "party_name" = 'First Name Last Name') AND "person_type_id" = (SELECT "person_type_id" FROM "person_type" WHERE "code" = 'INDIVIDUAL') AND "person_first_name" = 'First Name' AND "person_last_name" = 'Last Name'), (SELECT "organization_id" FROM "organization" WHERE "name" = 'Orgnization Name' AND "license" = 'XXXX-XXXXX-XXXX'), 'FOUR', 'FIVE', 'Good Service', 'Satisfied', 'THREE', NULL, NULL, NULL, NULL, NULL, NULL);
 INSERT INTO "contract" ("contract_from_id", "contract_to_id", "contract_status_id", "document_reference", "payment_type_id", "periodicity_id", "start_date", "end_date", "contract_type_id", "date_of_last_review", "date_of_next_review", "date_of_contract_review", "date_of_contract_approval", "created_by", "updated_at", "updated_by", "deleted_at", "deleted_by", "activity_log") VALUES ((SELECT "party_id" FROM "party" WHERE "party_type_id" = 'PERSON' AND "party_name" = 'First Name Last Name'), (SELECT "party_id" FROM "party" WHERE "party_type_id" = 'ORGANIZATION' AND "party_name" = 'Orgnization Name'), 'FINISHED', 'google.com', 'RENTS', 'WEEKLY', '2021-04-20T00:00:00.000Z', '2021-04-20T00:00:00.000Z', 'GENERAL_CONTRACT_FOR_SERVICES', '2021-04-20T00:00:00.000Z', '2021-04-20T00:00:00.000Z', '2021-04-20T00:00:00.000Z', '2021-04-20T00:00:00.000Z', NULL, NULL, NULL, NULL, NULL, NULL);
-INSERT INTO "risk_register" ("description", "risk_subject_id", "risk_type_id", "impact_to_the_organization", "rating_likelihood_id", "rating_impact_id", "rating_overall_risk_id", "controls_in_place", "control_effectivenes", "over_all_residual_risk_rating_id", "mitigation_further_actions", "control_monitor_mitigation_actions_tracking_strategy", "control_monitor_action_due_date", "control_monitor_risk_owner_id", "created_by", "updated_at", "updated_by", "deleted_at", "deleted_by", "activity_log") VALUES ('Risk description', 'TECHNICAL_RISK', 'QUALITY', 'Impact to the organization', 'THREE', 'THREE', 'THREE', 'Try forgot password', 1, NULL, 'Mitigation further actions', 'Control monitor mitigation actions tracking strategy', '2022-06-13', (SELECT "person_id" FROM "person" WHERE "party_id" = (SELECT "party_id" FROM "party" WHERE "party_type_id" = 'PERSON' AND "party_name" = 'First Name Last Name') AND "person_type_id" = 'INDIVIDUAL' AND "person_first_name" = 'First Name' AND "person_last_name" = 'Last Name'), NULL, NULL, NULL, NULL, NULL, NULL);
+INSERT INTO "risk_register" ("description", "risk_subject_id", "risk_type_id", "impact_to_the_organization", "rating_likelihood_id", "rating_impact_id", "rating_overall_risk_id", "controls_in_place", "control_effectivenes", "over_all_residual_risk_rating_id", "mitigation_further_actions", "control_monitor_mitigation_actions_tracking_strategy", "control_monitor_action_due_date", "control_monitor_risk_owner_id", "created_by", "updated_at", "updated_by", "deleted_at", "deleted_by", "activity_log") VALUES ('Risk description', 'TECHNICAL_RISK', 'QUALITY', 'Impact to the organization', 'THREE', 'THREE', 'THREE', 'Try forgot password', 1, NULL, 'Mitigation further actions', 'Control monitor mitigation actions tracking strategy', '2022-06-13', (SELECT "person_id" FROM "person" WHERE "party_id" = (SELECT "party_id" FROM "party" WHERE "party_type_id" = 'PERSON' AND "party_name" = 'First Name Last Name') AND "person_type_id" = (SELECT "person_type_id" FROM "person_type" WHERE "code" = 'INDIVIDUAL') AND "person_first_name" = 'First Name' AND "person_last_name" = 'Last Name'), NULL, NULL, NULL, NULL, NULL, NULL);
 INSERT INTO "asset" ("organization_id", "asset_retired_date", "asset_status_id", "asset_tag", "name", "description", "asset_type_id", "asset_workload_category", "assignment_id", "barcode_or_rfid_tag", "installed_date", "planned_retirement_date", "purchase_delivery_date", "purchase_order_date", "purchase_request_date", "serial_number", "tco_amount", "tco_currency", "created_by", "updated_at", "updated_by", "deleted_at", "deleted_by", "activity_log") VALUES ((SELECT "organization_id" FROM "organization" WHERE "name" = 'Orgnization Name' AND "license" = 'XXXX-XXXXX-XXXX'), NULL, 'IN_USE', '', 'Asset Name', 'Service used for asset etc', 'VIRTUAL_MACHINE', '', 'IN_USE', '', '2021-04-20', NULL, '2021-04-20', '2021-04-20', '2021-04-20', '', '100', 'dollar', NULL, NULL, NULL, NULL, NULL, NULL);
-INSERT INTO "incident" ("title", "incident_date", "time_and_time_zone", "asset_id", "category_id", "sub_category_id", "severity_id", "priority_id", "internal_or_external_id", "location", "it_service_impacted", "impacted_modules", "impacted_dept", "reported_by_id", "reported_to_id", "brief_description", "detailed_description", "assigned_to_id", "assigned_date", "investigation_details", "containment_details", "eradication_details", "business_impact", "lessons_learned", "status_id", "closed_date", "reopened_time", "feedback_from_business", "reported_to_regulatory", "report_date", "report_time", "created_by", "updated_at", "updated_by", "deleted_at", "deleted_by", "activity_log") VALUES ('Server Down - Due to CPU utilization reached 100%', '2021-04-20', '2021-04-20T00:00:00.000Z', (SELECT "asset_id" FROM "asset" WHERE "name" = 'Asset Name' AND "description" = 'Service used for asset etc' AND "asset_type_id" = 'VIRTUAL_MACHINE'), 'PERFORMANCE', 'HARDWARE_FAILURE', 'MAJOR', 'HIGH', 'COMPLAINT', 'USA', 'Application down', '', 'All', (SELECT "person_id" FROM "person" WHERE "party_id" = (SELECT "party_id" FROM "party" WHERE "party_type_id" = 'PERSON' AND "party_name" = 'First Name Last Name') AND "person_type_id" = 'INDIVIDUAL' AND "person_first_name" = 'First Name' AND "person_last_name" = 'Last Name'), (SELECT "person_id" FROM "person" WHERE "party_id" = (SELECT "party_id" FROM "party" WHERE "party_type_id" = 'PERSON' AND "party_name" = 'First Name Last Name') AND "person_type_id" = 'INDIVIDUAL' AND "person_first_name" = 'First Name' AND "person_last_name" = 'Last Name'), 'Server will down due to CPU utilization', 'We got an alert message of server due to CPU utilization reaching 100% on 02-07-2022 07:30 GTM', (SELECT "person_id" FROM "person" WHERE "party_id" = (SELECT "party_id" FROM "party" WHERE "party_type_id" = 'PERSON' AND "party_name" = 'First Name Last Name') AND "person_type_id" = 'INDIVIDUAL' AND "person_first_name" = 'First Name' AND "person_last_name" = 'Last Name'), '2021-04-20', 'Server was facing issue using due to insufficient harware specfication which cause high CPU utilization, resulting in Crashing of the application', 'Migrated few services to another server in that network range and Restarted server', 'Migrated few services to another server in that network range', 'Application was completely down', 'We need to evlaute the hardware specification and remaining CPU/Memory resources before deploying new applications', 'CLOSED', NULL, NULL, '', '', '2021-04-20', '2021-04-20T00:00:00.000Z', NULL, NULL, NULL, NULL, NULL, NULL);
+INSERT INTO "incident" ("title", "incident_date", "time_and_time_zone", "asset_id", "category_id", "sub_category_id", "severity_id", "priority_id", "internal_or_external_id", "location", "it_service_impacted", "impacted_modules", "impacted_dept", "reported_by_id", "reported_to_id", "brief_description", "detailed_description", "assigned_to_id", "assigned_date", "investigation_details", "containment_details", "eradication_details", "business_impact", "lessons_learned", "status_id", "closed_date", "reopened_time", "feedback_from_business", "reported_to_regulatory", "report_date", "report_time", "created_by", "updated_at", "updated_by", "deleted_at", "deleted_by", "activity_log") VALUES ('Server Down - Due to CPU utilization reached 100%', '2021-04-20', '2021-04-20T00:00:00.000Z', (SELECT "asset_id" FROM "asset" WHERE "name" = 'Asset Name' AND "description" = 'Service used for asset etc' AND "asset_type_id" = 'VIRTUAL_MACHINE'), 'PERFORMANCE', 'HARDWARE_FAILURE', 'MAJOR', 'HIGH', 'COMPLAINT', 'USA', 'Application down', '', 'All', (SELECT "person_id" FROM "person" WHERE "party_id" = (SELECT "party_id" FROM "party" WHERE "party_type_id" = 'PERSON' AND "party_name" = 'First Name Last Name') AND "person_type_id" = (SELECT "person_type_id" FROM "person_type" WHERE "code" = 'INDIVIDUAL') AND "person_first_name" = 'First Name' AND "person_last_name" = 'Last Name'), (SELECT "person_id" FROM "person" WHERE "party_id" = (SELECT "party_id" FROM "party" WHERE "party_type_id" = 'PERSON' AND "party_name" = 'First Name Last Name') AND "person_type_id" = (SELECT "person_type_id" FROM "person_type" WHERE "code" = 'INDIVIDUAL') AND "person_first_name" = 'First Name' AND "person_last_name" = 'Last Name'), 'Server will down due to CPU utilization', 'We got an alert message of server due to CPU utilization reaching 100% on 02-07-2022 07:30 GTM', (SELECT "person_id" FROM "person" WHERE "party_id" = (SELECT "party_id" FROM "party" WHERE "party_type_id" = 'PERSON' AND "party_name" = 'First Name Last Name') AND "person_type_id" = (SELECT "person_type_id" FROM "person_type" WHERE "code" = 'INDIVIDUAL') AND "person_first_name" = 'First Name' AND "person_last_name" = 'Last Name'), '2021-04-20', 'Server was facing issue using due to insufficient harware specfication which cause high CPU utilization, resulting in Crashing of the application', 'Migrated few services to another server in that network range and Restarted server', 'Migrated few services to another server in that network range', 'Application was completely down', 'We need to evlaute the hardware specification and remaining CPU/Memory resources before deploying new applications', 'CLOSED', NULL, NULL, '', '', '2021-04-20', '2021-04-20T00:00:00.000Z', NULL, NULL, NULL, NULL, NULL, NULL);
 INSERT INTO "incident_root_cause" ("incident_id", "source", "description", "probability_id", "testing_analysis", "solution", "likelihood_of_risk_id", "modification_of_the_reported_issue", "testing_for_modified_issue", "test_results", "created_by", "updated_at", "updated_by", "deleted_at", "deleted_by", "activity_log") VALUES ((SELECT "incident_id" FROM "incident" WHERE "title" = 'Server Down - Due to CPU utilization reached 100%' AND "sub_category_id" = 'HARDWARE_FAILURE' AND "severity_id" = 'MAJOR' AND "priority_id" = 'HIGH' AND "internal_or_external_id" = 'COMPLAINT' AND "location" = 'USA'), 'Server', 'Sample description', 'HIGH', 'Sample testing analysis', 'Server restarted', 'HIGH', 'No modifications', 'Sample test case', 'Sample test result', NULL, NULL, NULL, NULL, NULL, NULL);

--- a/pattern/infra-assurance/models.ts
+++ b/pattern/infra-assurance/models.ts
@@ -259,7 +259,6 @@ export const allReferenceTables: (
 )[] = [
   udm.execCtx,
   udm.partyType,
-  udm.partyRole,
   contractStatus,
   paymentType,
   periodicity,
@@ -287,9 +286,6 @@ export const allReferenceTables: (
   auditPurpose,
   auditorStatusType,
   udm.partyRelationType,
-  udm.partyIdentifierType,
-  udm.personType,
-  udm.contactType,
   trainingSubject,
   statusValues,
   ratingValue,
@@ -876,6 +872,10 @@ export const allContentTables: SQLa.TableDefinition<
   udm.EmitContext,
   typ.TypicalDomainQS
 >[] = [
+  udm.partyRole,
+  udm.partyIdentifierType,
+  udm.personType,
+  udm.contactType,
   udm.organizationRoleType,
   graph,
   boundary,
@@ -1241,6 +1241,57 @@ const vendorView = SQLa.safeViewDefinition(
   INNER JOIN contact_land l ON l.party_id = pr.party_id AND l.contact_type_id = 'OFFICIAL_ADDRESS'
   WHERE prl.party_role_id = 'VENDOR' AND prl.relation_type_id = 'ORGANIZATION_TO_PERSON'`;
 
+const partyRoleInsertion = udm
+  .partyRole.insertDML([{
+    code: "CUSTOMER",
+    value: "Customer",
+  }, {
+    code: "VENDOR",
+    value: "Vendor",
+  }]);
+
+const partyIdentifierTypeInsertion = udm
+  .partyIdentifierType.insertDML([{
+    code: "UUID",
+    value: "UUID",
+  }, {
+    code: "DRIVING_LICENSE",
+    value: "Driving License",
+  }, {
+    code: "PASSPORT",
+    value: "Passport",
+  }]);
+
+const personTypeInsertion = udm
+  .personType.insertDML([{
+    code: "INDIVIDUAL",
+    value: "Individual",
+  }, {
+    code: "PROFESSIONAL",
+    value: "Professional",
+  }]);
+
+const contactTypeInsertion = udm
+  .contactType.insertDML([{
+    code: "HOME_ADDRESS",
+    value: "Home Address",
+  }, {
+    code: "OFFICIAL_ADDRESS",
+    value: "Official Address",
+  }, {
+    code: "MOBILE_PHONE_NUMBER",
+    value: "Mobile Phone Number",
+  }, {
+    code: "LAND_PHONE_NUMBER",
+    value: "Land Phone Number",
+  }, {
+    code: "OFFICIAL_EMAIL",
+    value: "Official Email",
+  }, {
+    code: "PERSONAL_EMAIL",
+    value: "Personal Email",
+  }]);
+
 const organizationRoleTypeInsertion = udm
   .organizationRoleType.insertDML([{
     code: "PROJECT_MANAGER_TECHNOLOGY",
@@ -1367,6 +1418,14 @@ export function sqlDDL() {
 
     -- seed Data
     ${allReferenceTables.map(e => e.seedDML).flat()}
+
+    ${partyRoleInsertion}
+
+    ${partyIdentifierTypeInsertion}
+
+    ${personTypeInsertion}
+
+    ${contactTypeInsertion}
 
     ${organizationRoleTypeInsertion}
     `;

--- a/pattern/infra-assurance/models_test.fixture.puml
+++ b/pattern/infra-assurance/models_test.fixture.puml
@@ -10,6 +10,62 @@
     FontSize 12
   }
 
+  entity "party_role" as party_role {
+      **party_role_id**: INTEGER
+    --
+    * code: TEXT
+    * value: TEXT
+      created_at: TIMESTAMP
+      created_by: TEXT
+      updated_at: TIMESTAMP
+      updated_by: TEXT
+      deleted_at: TIMESTAMP
+      deleted_by: TEXT
+      activity_log: TEXT
+  }
+
+  entity "party_identifier_type" as party_identifier_type {
+      **party_identifier_type_id**: INTEGER
+    --
+    * code: TEXT
+    * value: TEXT
+      created_at: TIMESTAMP
+      created_by: TEXT
+      updated_at: TIMESTAMP
+      updated_by: TEXT
+      deleted_at: TIMESTAMP
+      deleted_by: TEXT
+      activity_log: TEXT
+  }
+
+  entity "person_type" as person_type {
+      **person_type_id**: INTEGER
+    --
+    * code: TEXT
+    * value: TEXT
+      created_at: TIMESTAMP
+      created_by: TEXT
+      updated_at: TIMESTAMP
+      updated_by: TEXT
+      deleted_at: TIMESTAMP
+      deleted_by: TEXT
+      activity_log: TEXT
+  }
+
+  entity "contact_type" as contact_type {
+      **contact_type_id**: INTEGER
+    --
+    * code: TEXT
+    * value: TEXT
+      created_at: TIMESTAMP
+      created_by: TEXT
+      updated_at: TIMESTAMP
+      updated_by: TEXT
+      deleted_at: TIMESTAMP
+      deleted_by: TEXT
+      activity_log: TEXT
+  }
+
   entity "organization_role_type" as organization_role_type {
       **organization_role_type_id**: INTEGER
     --
@@ -145,7 +201,7 @@
       **party_identifier_id**: INTEGER
     --
     * identifier_number: TEXT
-    * party_identifier_type_id: TEXT
+    * party_identifier_type_id: INTEGER
     * party_id: INTEGER
       created_at: TIMESTAMP
       created_by: TEXT
@@ -160,7 +216,7 @@
       **person_id**: INTEGER
     --
     * party_id: INTEGER
-    * person_type_id: TEXT
+    * person_type_id: INTEGER
     * person_first_name: TEXT
     * person_last_name: TEXT
       honorific_prefix: TEXT
@@ -180,7 +236,7 @@
     * party_id: INTEGER
     * related_party_id: INTEGER
     * relation_type_id: TEXT
-      party_role_id: TEXT
+      party_role_id: INTEGER
       created_at: TIMESTAMP
       created_by: TEXT
       updated_at: TIMESTAMP
@@ -224,7 +280,7 @@
   entity "contact_electronic" as contact_electronic {
       **contact_electronic_id**: INTEGER
     --
-    * contact_type_id: TEXT
+    * contact_type_id: INTEGER
     * party_id: INTEGER
     * electronics_details: TEXT
       created_at: TIMESTAMP
@@ -239,7 +295,7 @@
   entity "contact_land" as contact_land {
       **contact_land_id**: INTEGER
     --
-    * contact_type_id: TEXT
+    * contact_type_id: INTEGER
     * party_id: INTEGER
     * address_line1: TEXT
     * address_line2: TEXT
@@ -898,15 +954,20 @@
   graph |o..o{ boundary
   host |o..o{ host_boundary
   boundary |o..o{ raci_matrix_subject_boundary
+  party_identifier_type |o..o{ party_identifier
   party |o..o{ party_identifier
   party |o..o{ person
+  person_type |o..o{ person
   party |o..o{ party_relation
   party |o..o{ party_relation
+  party_role |o..o{ party_relation
   party |o..o{ organization
   person |o..o{ organization_role
   organization |o..o{ organization_role
   organization_role_type |o..o{ organization_role
+  contact_type |o..o{ contact_electronic
   party |o..o{ contact_electronic
+  contact_type |o..o{ contact_land
   party |o..o{ contact_land
   organization |o..o{ asset
   vulnerability_source |o..o{ vulnerability

--- a/pattern/infra-assurance/models_test.fixture.sh
+++ b/pattern/infra-assurance/models_test.fixture.sh
@@ -45,11 +45,6 @@ CREATE TABLE IF NOT EXISTS "party_type" (
     "value" TEXT NOT NULL,
     "created_at" TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 );
-CREATE TABLE IF NOT EXISTS "party_role_type" (
-    "code" TEXT PRIMARY KEY NOT NULL,
-    "value" TEXT NOT NULL,
-    "created_at" TIMESTAMP DEFAULT CURRENT_TIMESTAMP
-);
 CREATE TABLE IF NOT EXISTS "contract_status" (
     "code" TEXT PRIMARY KEY NOT NULL,
     "value" TEXT NOT NULL,
@@ -185,21 +180,6 @@ CREATE TABLE IF NOT EXISTS "party_relation_type" (
     "value" TEXT NOT NULL,
     "created_at" TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 );
-CREATE TABLE IF NOT EXISTS "party_identifier_type" (
-    "code" TEXT PRIMARY KEY NOT NULL,
-    "value" TEXT NOT NULL,
-    "created_at" TIMESTAMP DEFAULT CURRENT_TIMESTAMP
-);
-CREATE TABLE IF NOT EXISTS "person_type" (
-    "code" TEXT PRIMARY KEY NOT NULL,
-    "value" TEXT NOT NULL,
-    "created_at" TIMESTAMP DEFAULT CURRENT_TIMESTAMP
-);
-CREATE TABLE IF NOT EXISTS "contact_type" (
-    "code" TEXT PRIMARY KEY NOT NULL,
-    "value" TEXT NOT NULL,
-    "created_at" TIMESTAMP DEFAULT CURRENT_TIMESTAMP
-);
 CREATE TABLE IF NOT EXISTS "training_subject" (
     "code" TEXT PRIMARY KEY NOT NULL,
     "value" TEXT NOT NULL,
@@ -272,6 +252,58 @@ CREATE TABLE IF NOT EXISTS "asset_risk_type" (
 );
 
 -- content tables
+CREATE TABLE IF NOT EXISTS "party_role" (
+    "party_role_id" INTEGER PRIMARY KEY AUTOINCREMENT,
+    "code" TEXT /* UNIQUE COLUMN */ NOT NULL,
+    "value" TEXT NOT NULL,
+    "created_at" TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    "created_by" TEXT DEFAULT 'UNKNOWN',
+    "updated_at" TIMESTAMP,
+    "updated_by" TEXT,
+    "deleted_at" TIMESTAMP,
+    "deleted_by" TEXT,
+    "activity_log" TEXT,
+    UNIQUE("code")
+);
+CREATE TABLE IF NOT EXISTS "party_identifier_type" (
+    "party_identifier_type_id" INTEGER PRIMARY KEY AUTOINCREMENT,
+    "code" TEXT /* UNIQUE COLUMN */ NOT NULL,
+    "value" TEXT NOT NULL,
+    "created_at" TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    "created_by" TEXT DEFAULT 'UNKNOWN',
+    "updated_at" TIMESTAMP,
+    "updated_by" TEXT,
+    "deleted_at" TIMESTAMP,
+    "deleted_by" TEXT,
+    "activity_log" TEXT,
+    UNIQUE("code")
+);
+CREATE TABLE IF NOT EXISTS "person_type" (
+    "person_type_id" INTEGER PRIMARY KEY AUTOINCREMENT,
+    "code" TEXT /* UNIQUE COLUMN */ NOT NULL,
+    "value" TEXT NOT NULL,
+    "created_at" TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    "created_by" TEXT DEFAULT 'UNKNOWN',
+    "updated_at" TIMESTAMP,
+    "updated_by" TEXT,
+    "deleted_at" TIMESTAMP,
+    "deleted_by" TEXT,
+    "activity_log" TEXT,
+    UNIQUE("code")
+);
+CREATE TABLE IF NOT EXISTS "contact_type" (
+    "contact_type_id" INTEGER PRIMARY KEY AUTOINCREMENT,
+    "code" TEXT /* UNIQUE COLUMN */ NOT NULL,
+    "value" TEXT NOT NULL,
+    "created_at" TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    "created_by" TEXT DEFAULT 'UNKNOWN',
+    "updated_at" TIMESTAMP,
+    "updated_by" TEXT,
+    "deleted_at" TIMESTAMP,
+    "deleted_by" TEXT,
+    "activity_log" TEXT,
+    UNIQUE("code")
+);
 CREATE TABLE IF NOT EXISTS "organization_role_type" (
     "organization_role_type_id" INTEGER PRIMARY KEY AUTOINCREMENT,
     "code" TEXT /* UNIQUE COLUMN */ NOT NULL,
@@ -398,7 +430,7 @@ CREATE TABLE IF NOT EXISTS "party" (
 CREATE TABLE IF NOT EXISTS "party_identifier" (
     "party_identifier_id" INTEGER PRIMARY KEY AUTOINCREMENT,
     "identifier_number" TEXT NOT NULL,
-    "party_identifier_type_id" TEXT NOT NULL,
+    "party_identifier_type_id" INTEGER NOT NULL,
     "party_id" INTEGER NOT NULL,
     "created_at" TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     "created_by" TEXT DEFAULT 'UNKNOWN',
@@ -407,13 +439,13 @@ CREATE TABLE IF NOT EXISTS "party_identifier" (
     "deleted_at" TIMESTAMP,
     "deleted_by" TEXT,
     "activity_log" TEXT,
-    FOREIGN KEY("party_identifier_type_id") REFERENCES "party_identifier_type"("code"),
+    FOREIGN KEY("party_identifier_type_id") REFERENCES "party_identifier_type"("party_identifier_type_id"),
     FOREIGN KEY("party_id") REFERENCES "party"("party_id")
 );
 CREATE TABLE IF NOT EXISTS "person" (
     "person_id" INTEGER PRIMARY KEY AUTOINCREMENT,
     "party_id" INTEGER NOT NULL,
-    "person_type_id" TEXT NOT NULL,
+    "person_type_id" INTEGER NOT NULL,
     "person_first_name" TEXT NOT NULL,
     "person_last_name" TEXT NOT NULL,
     "honorific_prefix" TEXT,
@@ -426,14 +458,14 @@ CREATE TABLE IF NOT EXISTS "person" (
     "deleted_by" TEXT,
     "activity_log" TEXT,
     FOREIGN KEY("party_id") REFERENCES "party"("party_id"),
-    FOREIGN KEY("person_type_id") REFERENCES "person_type"("code")
+    FOREIGN KEY("person_type_id") REFERENCES "person_type"("person_type_id")
 );
 CREATE TABLE IF NOT EXISTS "party_relation" (
     "party_relation_id" INTEGER PRIMARY KEY AUTOINCREMENT,
     "party_id" INTEGER NOT NULL,
     "related_party_id" INTEGER NOT NULL,
     "relation_type_id" TEXT NOT NULL,
-    "party_role_id" TEXT,
+    "party_role_id" INTEGER,
     "created_at" TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     "created_by" TEXT DEFAULT 'UNKNOWN',
     "updated_at" TIMESTAMP,
@@ -444,7 +476,7 @@ CREATE TABLE IF NOT EXISTS "party_relation" (
     FOREIGN KEY("party_id") REFERENCES "party"("party_id"),
     FOREIGN KEY("related_party_id") REFERENCES "party"("party_id"),
     FOREIGN KEY("relation_type_id") REFERENCES "party_relation_type"("code"),
-    FOREIGN KEY("party_role_id") REFERENCES "party_role_type"("code")
+    FOREIGN KEY("party_role_id") REFERENCES "party_role"("party_role_id")
 );
 CREATE TABLE IF NOT EXISTS "organization" (
     "organization_id" INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -479,7 +511,7 @@ CREATE TABLE IF NOT EXISTS "organization_role" (
 );
 CREATE TABLE IF NOT EXISTS "contact_electronic" (
     "contact_electronic_id" INTEGER PRIMARY KEY AUTOINCREMENT,
-    "contact_type_id" TEXT NOT NULL,
+    "contact_type_id" INTEGER NOT NULL,
     "party_id" INTEGER NOT NULL,
     "electronics_details" TEXT NOT NULL,
     "created_at" TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
@@ -489,12 +521,12 @@ CREATE TABLE IF NOT EXISTS "contact_electronic" (
     "deleted_at" TIMESTAMP,
     "deleted_by" TEXT,
     "activity_log" TEXT,
-    FOREIGN KEY("contact_type_id") REFERENCES "contact_type"("code"),
+    FOREIGN KEY("contact_type_id") REFERENCES "contact_type"("contact_type_id"),
     FOREIGN KEY("party_id") REFERENCES "party"("party_id")
 );
 CREATE TABLE IF NOT EXISTS "contact_land" (
     "contact_land_id" INTEGER PRIMARY KEY AUTOINCREMENT,
-    "contact_type_id" TEXT NOT NULL,
+    "contact_type_id" INTEGER NOT NULL,
     "party_id" INTEGER NOT NULL,
     "address_line1" TEXT NOT NULL,
     "address_line2" TEXT NOT NULL,
@@ -509,7 +541,7 @@ CREATE TABLE IF NOT EXISTS "contact_land" (
     "deleted_at" TIMESTAMP,
     "deleted_by" TEXT,
     "activity_log" TEXT,
-    FOREIGN KEY("contact_type_id") REFERENCES "contact_type"("code"),
+    FOREIGN KEY("contact_type_id") REFERENCES "contact_type"("contact_type_id"),
     FOREIGN KEY("party_id") REFERENCES "party"("party_id")
 );
 CREATE TABLE IF NOT EXISTS "asset" (
@@ -1363,8 +1395,6 @@ INSERT INTO "execution_context" ("code", "value") VALUES ('SANDBOX', 'sandbox');
 INSERT INTO "execution_context" ("code", "value") VALUES ('EXPERIMENTAL', 'experimental');
 INSERT INTO "party_type" ("code", "value") VALUES ('PERSON', 'Person');
 INSERT INTO "party_type" ("code", "value") VALUES ('ORGANIZATION', 'Organization');
-INSERT INTO "party_role_type" ("code", "value") VALUES ('CUSTOMER', 'Customer');
-INSERT INTO "party_role_type" ("code", "value") VALUES ('VENDOR', 'Vendor');
 INSERT INTO "contract_status" ("code", "value") VALUES ('ACTIVE', 'Active');
 INSERT INTO "contract_status" ("code", "value") VALUES ('AWAITING_APPROVAL', 'Awaiting Approval');
 INSERT INTO "contract_status" ("code", "value") VALUES ('AWAITING_APPROVAL_FOR_RENEWAL', 'Awaiting Approval For Renewal');
@@ -1598,17 +1628,6 @@ INSERT INTO "audit_status" ("code", "value") VALUES ('ACCEPTED', 'Accepted');
 INSERT INTO "party_relation_type" ("code", "value") VALUES ('PERSON_TO_PERSON', 'Person To Person');
 INSERT INTO "party_relation_type" ("code", "value") VALUES ('ORGANIZATION_TO_PERSON', 'Organization To Person');
 INSERT INTO "party_relation_type" ("code", "value") VALUES ('ORGANIZATION_TO_ORGANIZATION', 'Organization To Organization');
-INSERT INTO "party_identifier_type" ("code", "value") VALUES ('UUID', 'UUID');
-INSERT INTO "party_identifier_type" ("code", "value") VALUES ('DRIVING_LICENSE', 'Driving License');
-INSERT INTO "party_identifier_type" ("code", "value") VALUES ('PASSPORT', 'Passport');
-INSERT INTO "person_type" ("code", "value") VALUES ('INDIVIDUAL', 'Individual');
-INSERT INTO "person_type" ("code", "value") VALUES ('PROFESSIONAL', 'Professional');
-INSERT INTO "contact_type" ("code", "value") VALUES ('HOME_ADDRESS', 'Home Address');
-INSERT INTO "contact_type" ("code", "value") VALUES ('OFFICIAL_ADDRESS', 'Official Address');
-INSERT INTO "contact_type" ("code", "value") VALUES ('MOBILE_PHONE_NUMBER', 'Mobile Phone Number');
-INSERT INTO "contact_type" ("code", "value") VALUES ('LAND_PHONE_NUMBER', 'Land Phone Number');
-INSERT INTO "contact_type" ("code", "value") VALUES ('OFFICIAL_EMAIL', 'Official Email');
-INSERT INTO "contact_type" ("code", "value") VALUES ('PERSONAL_EMAIL', 'Personal Email');
 INSERT INTO "training_subject" ("code", "value") VALUES ('HIPAA', 'HIPAA');
 INSERT INTO "training_subject" ("code", "value") VALUES ('CYBER_SECURITY', 'Cyber Security');
 INSERT INTO "training_subject" ("code", "value") VALUES ('OBSERVABILITY_OPEN_TELEMETRY', 'Observability Open Telemetry');
@@ -1705,6 +1724,27 @@ INSERT INTO "incident_status" ("code", "value") VALUES ('SUSPENDED', 'Suspended'
 INSERT INTO "incident_status" ("code", "value") VALUES ('WORK_IN_PROGRESS', 'Work In Progress');
 INSERT INTO "asset_risk_type" ("code", "value") VALUES ('SECURITY', 'Security');
 
+INSERT INTO "party_role" ("code", "value", "created_by", "updated_at", "updated_by", "deleted_at", "deleted_by", "activity_log")
+       VALUES ('CUSTOMER', 'Customer', NULL, NULL, NULL, NULL, NULL, NULL),
+              ('VENDOR', 'Vendor', NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO "party_identifier_type" ("code", "value", "created_by", "updated_at", "updated_by", "deleted_at", "deleted_by", "activity_log")
+       VALUES ('UUID', 'UUID', NULL, NULL, NULL, NULL, NULL, NULL),
+              ('DRIVING_LICENSE', 'Driving License', NULL, NULL, NULL, NULL, NULL, NULL),
+              ('PASSPORT', 'Passport', NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO "person_type" ("code", "value", "created_by", "updated_at", "updated_by", "deleted_at", "deleted_by", "activity_log")
+       VALUES ('INDIVIDUAL', 'Individual', NULL, NULL, NULL, NULL, NULL, NULL),
+              ('PROFESSIONAL', 'Professional', NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO "contact_type" ("code", "value", "created_by", "updated_at", "updated_by", "deleted_at", "deleted_by", "activity_log")
+       VALUES ('HOME_ADDRESS', 'Home Address', NULL, NULL, NULL, NULL, NULL, NULL),
+              ('OFFICIAL_ADDRESS', 'Official Address', NULL, NULL, NULL, NULL, NULL, NULL),
+              ('MOBILE_PHONE_NUMBER', 'Mobile Phone Number', NULL, NULL, NULL, NULL, NULL, NULL),
+              ('LAND_PHONE_NUMBER', 'Land Phone Number', NULL, NULL, NULL, NULL, NULL, NULL),
+              ('OFFICIAL_EMAIL', 'Official Email', NULL, NULL, NULL, NULL, NULL, NULL),
+              ('PERSONAL_EMAIL', 'Personal Email', NULL, NULL, NULL, NULL, NULL, NULL);
+
 INSERT INTO "organization_role_type" ("code", "value", "created_by", "updated_at", "updated_by", "deleted_at", "deleted_by", "activity_log")
        VALUES ('PROJECT_MANAGER_TECHNOLOGY', 'Project Manager Technology', NULL, NULL, NULL, NULL, NULL, NULL),
               ('PROJECT_MANAGER_QUALITY', 'Project Manager Quality', NULL, NULL, NULL, NULL, NULL, NULL),
@@ -1744,18 +1784,18 @@ INSERT INTO "raci_matrix_activity" ("activity", "created_by", "updated_at", "upd
 
 INSERT INTO "party" ("party_type_id", "party_name", "created_by", "updated_at", "updated_by", "deleted_at", "deleted_by", "activity_log") VALUES ('PERSON', 'person', NULL, NULL, NULL, NULL, NULL, NULL);
 
-INSERT INTO "party_identifier" ("identifier_number", "party_identifier_type_id", "party_id", "created_by", "updated_at", "updated_by", "deleted_at", "deleted_by", "activity_log") VALUES ('test identifier', 'PASSPORT', (SELECT "party_id" FROM "party" WHERE "party_type_id" = 'PERSON' AND "party_name" = 'person'), NULL, NULL, NULL, NULL, NULL, NULL);
+INSERT INTO "party_identifier" ("identifier_number", "party_identifier_type_id", "party_id", "created_by", "updated_at", "updated_by", "deleted_at", "deleted_by", "activity_log") VALUES ('test identifier', (SELECT "party_identifier_type_id" FROM "party_identifier_type" WHERE "code" = 'PASSPORT'), (SELECT "party_id" FROM "party" WHERE "party_type_id" = 'PERSON' AND "party_name" = 'person'), NULL, NULL, NULL, NULL, NULL, NULL);
 
-INSERT INTO "person" ("party_id", "person_type_id", "person_first_name", "person_last_name", "honorific_prefix", "honorific_suffix", "created_by", "updated_at", "updated_by", "deleted_at", "deleted_by", "activity_log") VALUES ((SELECT "party_id" FROM "party" WHERE "party_type_id" = 'PERSON' AND "party_name" = 'person'), 'PROFESSIONAL', 'Test First Name', 'Test Last Name', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+INSERT INTO "person" ("party_id", "person_type_id", "person_first_name", "person_last_name", "honorific_prefix", "honorific_suffix", "created_by", "updated_at", "updated_by", "deleted_at", "deleted_by", "activity_log") VALUES ((SELECT "party_id" FROM "party" WHERE "party_type_id" = 'PERSON' AND "party_name" = 'person'), (SELECT "person_type_id" FROM "person_type" WHERE "code" = 'PROFESSIONAL'), 'Test First Name', 'Test Last Name', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
-INSERT INTO "party_relation" ("party_id", "related_party_id", "relation_type_id", "party_role_id", "created_by", "updated_at", "updated_by", "deleted_at", "deleted_by", "activity_log") VALUES ((SELECT "party_id" FROM "party" WHERE "party_type_id" = 'PERSON' AND "party_name" = 'person'), (SELECT "party_id" FROM "party" WHERE "party_type_id" = 'PERSON' AND "party_name" = 'person'), 'ORGANIZATION_TO_PERSON', 'VENDOR', NULL, NULL, NULL, NULL, NULL, NULL);
+INSERT INTO "party_relation" ("party_id", "related_party_id", "relation_type_id", "party_role_id", "created_by", "updated_at", "updated_by", "deleted_at", "deleted_by", "activity_log") VALUES ((SELECT "party_id" FROM "party" WHERE "party_type_id" = 'PERSON' AND "party_name" = 'person'), (SELECT "party_id" FROM "party" WHERE "party_type_id" = 'PERSON' AND "party_name" = 'person'), 'ORGANIZATION_TO_PERSON', (SELECT "party_role_id" FROM "party_role" WHERE "code" = 'VENDOR'), NULL, NULL, NULL, NULL, NULL, NULL);
 
 INSERT INTO "organization" ("party_id", "name", "license", "registration_date", "created_by", "updated_at", "updated_by", "deleted_at", "deleted_by", "activity_log") VALUES ((SELECT "party_id" FROM "party" WHERE "party_type_id" = 'PERSON' AND "party_name" = 'person'), 'Test Name', 'Test License', '2023-02-06', NULL, NULL, NULL, NULL, NULL, NULL);
 
 
 INSERT INTO "organization_role" ("person_id", "organization_id", "organization_role_type_id", "created_by", "updated_at", "updated_by", "deleted_at", "deleted_by", "activity_log") VALUES ((SELECT "person_id" FROM "person" WHERE "person_first_name" = 'Test First Name' AND "person_last_name" = 'Test Last Name'), (SELECT "organization_id" FROM "organization" WHERE "name" = 'Test Name'), (SELECT "organization_role_type_id" FROM "organization_role_type" WHERE "code" = 'ASSOCIATE_MANAGER_TECHNOLOGY'), NULL, NULL, NULL, NULL, NULL, NULL);
 
-INSERT INTO "contact_electronic" ("contact_type_id", "party_id", "electronics_details", "created_by", "updated_at", "updated_by", "deleted_at", "deleted_by", "activity_log") VALUES ('MOBILE_PHONE_NUMBER', (SELECT "party_id" FROM "party" WHERE "party_type_id" = 'PERSON' AND "party_name" = 'person'), 'electronics details', NULL, NULL, NULL, NULL, NULL, NULL);
+INSERT INTO "contact_electronic" ("contact_type_id", "party_id", "electronics_details", "created_by", "updated_at", "updated_by", "deleted_at", "deleted_by", "activity_log") VALUES ((SELECT "contact_type_id" FROM "contact_type" WHERE "code" = 'MOBILE_PHONE_NUMBER'), (SELECT "party_id" FROM "party" WHERE "party_type_id" = 'PERSON' AND "party_name" = 'person'), 'electronics details', NULL, NULL, NULL, NULL, NULL, NULL);
 
 -- the .dump in the last line is necessary because we load into :memory:
 -- first because performance is better and then emit all the SQL for saving

--- a/pattern/infra-assurance/models_test.fixture.sql
+++ b/pattern/infra-assurance/models_test.fixture.sql
@@ -11,11 +11,6 @@ CREATE TABLE IF NOT EXISTS "party_type" (
     "value" TEXT NOT NULL,
     "created_at" TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 );
-CREATE TABLE IF NOT EXISTS "party_role_type" (
-    "code" TEXT PRIMARY KEY NOT NULL,
-    "value" TEXT NOT NULL,
-    "created_at" TIMESTAMP DEFAULT CURRENT_TIMESTAMP
-);
 CREATE TABLE IF NOT EXISTS "contract_status" (
     "code" TEXT PRIMARY KEY NOT NULL,
     "value" TEXT NOT NULL,
@@ -151,21 +146,6 @@ CREATE TABLE IF NOT EXISTS "party_relation_type" (
     "value" TEXT NOT NULL,
     "created_at" TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 );
-CREATE TABLE IF NOT EXISTS "party_identifier_type" (
-    "code" TEXT PRIMARY KEY NOT NULL,
-    "value" TEXT NOT NULL,
-    "created_at" TIMESTAMP DEFAULT CURRENT_TIMESTAMP
-);
-CREATE TABLE IF NOT EXISTS "person_type" (
-    "code" TEXT PRIMARY KEY NOT NULL,
-    "value" TEXT NOT NULL,
-    "created_at" TIMESTAMP DEFAULT CURRENT_TIMESTAMP
-);
-CREATE TABLE IF NOT EXISTS "contact_type" (
-    "code" TEXT PRIMARY KEY NOT NULL,
-    "value" TEXT NOT NULL,
-    "created_at" TIMESTAMP DEFAULT CURRENT_TIMESTAMP
-);
 CREATE TABLE IF NOT EXISTS "training_subject" (
     "code" TEXT PRIMARY KEY NOT NULL,
     "value" TEXT NOT NULL,
@@ -238,6 +218,58 @@ CREATE TABLE IF NOT EXISTS "asset_risk_type" (
 );
 
 -- content tables
+CREATE TABLE IF NOT EXISTS "party_role" (
+    "party_role_id" INTEGER PRIMARY KEY AUTOINCREMENT,
+    "code" TEXT /* UNIQUE COLUMN */ NOT NULL,
+    "value" TEXT NOT NULL,
+    "created_at" TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    "created_by" TEXT DEFAULT 'UNKNOWN',
+    "updated_at" TIMESTAMP,
+    "updated_by" TEXT,
+    "deleted_at" TIMESTAMP,
+    "deleted_by" TEXT,
+    "activity_log" TEXT,
+    UNIQUE("code")
+);
+CREATE TABLE IF NOT EXISTS "party_identifier_type" (
+    "party_identifier_type_id" INTEGER PRIMARY KEY AUTOINCREMENT,
+    "code" TEXT /* UNIQUE COLUMN */ NOT NULL,
+    "value" TEXT NOT NULL,
+    "created_at" TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    "created_by" TEXT DEFAULT 'UNKNOWN',
+    "updated_at" TIMESTAMP,
+    "updated_by" TEXT,
+    "deleted_at" TIMESTAMP,
+    "deleted_by" TEXT,
+    "activity_log" TEXT,
+    UNIQUE("code")
+);
+CREATE TABLE IF NOT EXISTS "person_type" (
+    "person_type_id" INTEGER PRIMARY KEY AUTOINCREMENT,
+    "code" TEXT /* UNIQUE COLUMN */ NOT NULL,
+    "value" TEXT NOT NULL,
+    "created_at" TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    "created_by" TEXT DEFAULT 'UNKNOWN',
+    "updated_at" TIMESTAMP,
+    "updated_by" TEXT,
+    "deleted_at" TIMESTAMP,
+    "deleted_by" TEXT,
+    "activity_log" TEXT,
+    UNIQUE("code")
+);
+CREATE TABLE IF NOT EXISTS "contact_type" (
+    "contact_type_id" INTEGER PRIMARY KEY AUTOINCREMENT,
+    "code" TEXT /* UNIQUE COLUMN */ NOT NULL,
+    "value" TEXT NOT NULL,
+    "created_at" TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    "created_by" TEXT DEFAULT 'UNKNOWN',
+    "updated_at" TIMESTAMP,
+    "updated_by" TEXT,
+    "deleted_at" TIMESTAMP,
+    "deleted_by" TEXT,
+    "activity_log" TEXT,
+    UNIQUE("code")
+);
 CREATE TABLE IF NOT EXISTS "organization_role_type" (
     "organization_role_type_id" INTEGER PRIMARY KEY AUTOINCREMENT,
     "code" TEXT /* UNIQUE COLUMN */ NOT NULL,
@@ -364,7 +396,7 @@ CREATE TABLE IF NOT EXISTS "party" (
 CREATE TABLE IF NOT EXISTS "party_identifier" (
     "party_identifier_id" INTEGER PRIMARY KEY AUTOINCREMENT,
     "identifier_number" TEXT NOT NULL,
-    "party_identifier_type_id" TEXT NOT NULL,
+    "party_identifier_type_id" INTEGER NOT NULL,
     "party_id" INTEGER NOT NULL,
     "created_at" TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     "created_by" TEXT DEFAULT 'UNKNOWN',
@@ -373,13 +405,13 @@ CREATE TABLE IF NOT EXISTS "party_identifier" (
     "deleted_at" TIMESTAMP,
     "deleted_by" TEXT,
     "activity_log" TEXT,
-    FOREIGN KEY("party_identifier_type_id") REFERENCES "party_identifier_type"("code"),
+    FOREIGN KEY("party_identifier_type_id") REFERENCES "party_identifier_type"("party_identifier_type_id"),
     FOREIGN KEY("party_id") REFERENCES "party"("party_id")
 );
 CREATE TABLE IF NOT EXISTS "person" (
     "person_id" INTEGER PRIMARY KEY AUTOINCREMENT,
     "party_id" INTEGER NOT NULL,
-    "person_type_id" TEXT NOT NULL,
+    "person_type_id" INTEGER NOT NULL,
     "person_first_name" TEXT NOT NULL,
     "person_last_name" TEXT NOT NULL,
     "honorific_prefix" TEXT,
@@ -392,14 +424,14 @@ CREATE TABLE IF NOT EXISTS "person" (
     "deleted_by" TEXT,
     "activity_log" TEXT,
     FOREIGN KEY("party_id") REFERENCES "party"("party_id"),
-    FOREIGN KEY("person_type_id") REFERENCES "person_type"("code")
+    FOREIGN KEY("person_type_id") REFERENCES "person_type"("person_type_id")
 );
 CREATE TABLE IF NOT EXISTS "party_relation" (
     "party_relation_id" INTEGER PRIMARY KEY AUTOINCREMENT,
     "party_id" INTEGER NOT NULL,
     "related_party_id" INTEGER NOT NULL,
     "relation_type_id" TEXT NOT NULL,
-    "party_role_id" TEXT,
+    "party_role_id" INTEGER,
     "created_at" TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     "created_by" TEXT DEFAULT 'UNKNOWN',
     "updated_at" TIMESTAMP,
@@ -410,7 +442,7 @@ CREATE TABLE IF NOT EXISTS "party_relation" (
     FOREIGN KEY("party_id") REFERENCES "party"("party_id"),
     FOREIGN KEY("related_party_id") REFERENCES "party"("party_id"),
     FOREIGN KEY("relation_type_id") REFERENCES "party_relation_type"("code"),
-    FOREIGN KEY("party_role_id") REFERENCES "party_role_type"("code")
+    FOREIGN KEY("party_role_id") REFERENCES "party_role"("party_role_id")
 );
 CREATE TABLE IF NOT EXISTS "organization" (
     "organization_id" INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -445,7 +477,7 @@ CREATE TABLE IF NOT EXISTS "organization_role" (
 );
 CREATE TABLE IF NOT EXISTS "contact_electronic" (
     "contact_electronic_id" INTEGER PRIMARY KEY AUTOINCREMENT,
-    "contact_type_id" TEXT NOT NULL,
+    "contact_type_id" INTEGER NOT NULL,
     "party_id" INTEGER NOT NULL,
     "electronics_details" TEXT NOT NULL,
     "created_at" TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
@@ -455,12 +487,12 @@ CREATE TABLE IF NOT EXISTS "contact_electronic" (
     "deleted_at" TIMESTAMP,
     "deleted_by" TEXT,
     "activity_log" TEXT,
-    FOREIGN KEY("contact_type_id") REFERENCES "contact_type"("code"),
+    FOREIGN KEY("contact_type_id") REFERENCES "contact_type"("contact_type_id"),
     FOREIGN KEY("party_id") REFERENCES "party"("party_id")
 );
 CREATE TABLE IF NOT EXISTS "contact_land" (
     "contact_land_id" INTEGER PRIMARY KEY AUTOINCREMENT,
-    "contact_type_id" TEXT NOT NULL,
+    "contact_type_id" INTEGER NOT NULL,
     "party_id" INTEGER NOT NULL,
     "address_line1" TEXT NOT NULL,
     "address_line2" TEXT NOT NULL,
@@ -475,7 +507,7 @@ CREATE TABLE IF NOT EXISTS "contact_land" (
     "deleted_at" TIMESTAMP,
     "deleted_by" TEXT,
     "activity_log" TEXT,
-    FOREIGN KEY("contact_type_id") REFERENCES "contact_type"("code"),
+    FOREIGN KEY("contact_type_id") REFERENCES "contact_type"("contact_type_id"),
     FOREIGN KEY("party_id") REFERENCES "party"("party_id")
 );
 CREATE TABLE IF NOT EXISTS "asset" (
@@ -1329,8 +1361,6 @@ INSERT INTO "execution_context" ("code", "value") VALUES ('SANDBOX', 'sandbox');
 INSERT INTO "execution_context" ("code", "value") VALUES ('EXPERIMENTAL', 'experimental');
 INSERT INTO "party_type" ("code", "value") VALUES ('PERSON', 'Person');
 INSERT INTO "party_type" ("code", "value") VALUES ('ORGANIZATION', 'Organization');
-INSERT INTO "party_role_type" ("code", "value") VALUES ('CUSTOMER', 'Customer');
-INSERT INTO "party_role_type" ("code", "value") VALUES ('VENDOR', 'Vendor');
 INSERT INTO "contract_status" ("code", "value") VALUES ('ACTIVE', 'Active');
 INSERT INTO "contract_status" ("code", "value") VALUES ('AWAITING_APPROVAL', 'Awaiting Approval');
 INSERT INTO "contract_status" ("code", "value") VALUES ('AWAITING_APPROVAL_FOR_RENEWAL', 'Awaiting Approval For Renewal');
@@ -1564,17 +1594,6 @@ INSERT INTO "audit_status" ("code", "value") VALUES ('ACCEPTED', 'Accepted');
 INSERT INTO "party_relation_type" ("code", "value") VALUES ('PERSON_TO_PERSON', 'Person To Person');
 INSERT INTO "party_relation_type" ("code", "value") VALUES ('ORGANIZATION_TO_PERSON', 'Organization To Person');
 INSERT INTO "party_relation_type" ("code", "value") VALUES ('ORGANIZATION_TO_ORGANIZATION', 'Organization To Organization');
-INSERT INTO "party_identifier_type" ("code", "value") VALUES ('UUID', 'UUID');
-INSERT INTO "party_identifier_type" ("code", "value") VALUES ('DRIVING_LICENSE', 'Driving License');
-INSERT INTO "party_identifier_type" ("code", "value") VALUES ('PASSPORT', 'Passport');
-INSERT INTO "person_type" ("code", "value") VALUES ('INDIVIDUAL', 'Individual');
-INSERT INTO "person_type" ("code", "value") VALUES ('PROFESSIONAL', 'Professional');
-INSERT INTO "contact_type" ("code", "value") VALUES ('HOME_ADDRESS', 'Home Address');
-INSERT INTO "contact_type" ("code", "value") VALUES ('OFFICIAL_ADDRESS', 'Official Address');
-INSERT INTO "contact_type" ("code", "value") VALUES ('MOBILE_PHONE_NUMBER', 'Mobile Phone Number');
-INSERT INTO "contact_type" ("code", "value") VALUES ('LAND_PHONE_NUMBER', 'Land Phone Number');
-INSERT INTO "contact_type" ("code", "value") VALUES ('OFFICIAL_EMAIL', 'Official Email');
-INSERT INTO "contact_type" ("code", "value") VALUES ('PERSONAL_EMAIL', 'Personal Email');
 INSERT INTO "training_subject" ("code", "value") VALUES ('HIPAA', 'HIPAA');
 INSERT INTO "training_subject" ("code", "value") VALUES ('CYBER_SECURITY', 'Cyber Security');
 INSERT INTO "training_subject" ("code", "value") VALUES ('OBSERVABILITY_OPEN_TELEMETRY', 'Observability Open Telemetry');
@@ -1671,6 +1690,27 @@ INSERT INTO "incident_status" ("code", "value") VALUES ('SUSPENDED', 'Suspended'
 INSERT INTO "incident_status" ("code", "value") VALUES ('WORK_IN_PROGRESS', 'Work In Progress');
 INSERT INTO "asset_risk_type" ("code", "value") VALUES ('SECURITY', 'Security');
 
+INSERT INTO "party_role" ("code", "value", "created_by", "updated_at", "updated_by", "deleted_at", "deleted_by", "activity_log")
+       VALUES ('CUSTOMER', 'Customer', NULL, NULL, NULL, NULL, NULL, NULL),
+              ('VENDOR', 'Vendor', NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO "party_identifier_type" ("code", "value", "created_by", "updated_at", "updated_by", "deleted_at", "deleted_by", "activity_log")
+       VALUES ('UUID', 'UUID', NULL, NULL, NULL, NULL, NULL, NULL),
+              ('DRIVING_LICENSE', 'Driving License', NULL, NULL, NULL, NULL, NULL, NULL),
+              ('PASSPORT', 'Passport', NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO "person_type" ("code", "value", "created_by", "updated_at", "updated_by", "deleted_at", "deleted_by", "activity_log")
+       VALUES ('INDIVIDUAL', 'Individual', NULL, NULL, NULL, NULL, NULL, NULL),
+              ('PROFESSIONAL', 'Professional', NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO "contact_type" ("code", "value", "created_by", "updated_at", "updated_by", "deleted_at", "deleted_by", "activity_log")
+       VALUES ('HOME_ADDRESS', 'Home Address', NULL, NULL, NULL, NULL, NULL, NULL),
+              ('OFFICIAL_ADDRESS', 'Official Address', NULL, NULL, NULL, NULL, NULL, NULL),
+              ('MOBILE_PHONE_NUMBER', 'Mobile Phone Number', NULL, NULL, NULL, NULL, NULL, NULL),
+              ('LAND_PHONE_NUMBER', 'Land Phone Number', NULL, NULL, NULL, NULL, NULL, NULL),
+              ('OFFICIAL_EMAIL', 'Official Email', NULL, NULL, NULL, NULL, NULL, NULL),
+              ('PERSONAL_EMAIL', 'Personal Email', NULL, NULL, NULL, NULL, NULL, NULL);
+
 INSERT INTO "organization_role_type" ("code", "value", "created_by", "updated_at", "updated_by", "deleted_at", "deleted_by", "activity_log")
        VALUES ('PROJECT_MANAGER_TECHNOLOGY', 'Project Manager Technology', NULL, NULL, NULL, NULL, NULL, NULL),
               ('PROJECT_MANAGER_QUALITY', 'Project Manager Quality', NULL, NULL, NULL, NULL, NULL, NULL),
@@ -1710,15 +1750,15 @@ INSERT INTO "raci_matrix_activity" ("activity", "created_by", "updated_at", "upd
 
 INSERT INTO "party" ("party_type_id", "party_name", "created_by", "updated_at", "updated_by", "deleted_at", "deleted_by", "activity_log") VALUES ('PERSON', 'person', NULL, NULL, NULL, NULL, NULL, NULL);
 
-INSERT INTO "party_identifier" ("identifier_number", "party_identifier_type_id", "party_id", "created_by", "updated_at", "updated_by", "deleted_at", "deleted_by", "activity_log") VALUES ('test identifier', 'PASSPORT', (SELECT "party_id" FROM "party" WHERE "party_type_id" = 'PERSON' AND "party_name" = 'person'), NULL, NULL, NULL, NULL, NULL, NULL);
+INSERT INTO "party_identifier" ("identifier_number", "party_identifier_type_id", "party_id", "created_by", "updated_at", "updated_by", "deleted_at", "deleted_by", "activity_log") VALUES ('test identifier', (SELECT "party_identifier_type_id" FROM "party_identifier_type" WHERE "code" = 'PASSPORT'), (SELECT "party_id" FROM "party" WHERE "party_type_id" = 'PERSON' AND "party_name" = 'person'), NULL, NULL, NULL, NULL, NULL, NULL);
 
-INSERT INTO "person" ("party_id", "person_type_id", "person_first_name", "person_last_name", "honorific_prefix", "honorific_suffix", "created_by", "updated_at", "updated_by", "deleted_at", "deleted_by", "activity_log") VALUES ((SELECT "party_id" FROM "party" WHERE "party_type_id" = 'PERSON' AND "party_name" = 'person'), 'PROFESSIONAL', 'Test First Name', 'Test Last Name', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+INSERT INTO "person" ("party_id", "person_type_id", "person_first_name", "person_last_name", "honorific_prefix", "honorific_suffix", "created_by", "updated_at", "updated_by", "deleted_at", "deleted_by", "activity_log") VALUES ((SELECT "party_id" FROM "party" WHERE "party_type_id" = 'PERSON' AND "party_name" = 'person'), (SELECT "person_type_id" FROM "person_type" WHERE "code" = 'PROFESSIONAL'), 'Test First Name', 'Test Last Name', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
-INSERT INTO "party_relation" ("party_id", "related_party_id", "relation_type_id", "party_role_id", "created_by", "updated_at", "updated_by", "deleted_at", "deleted_by", "activity_log") VALUES ((SELECT "party_id" FROM "party" WHERE "party_type_id" = 'PERSON' AND "party_name" = 'person'), (SELECT "party_id" FROM "party" WHERE "party_type_id" = 'PERSON' AND "party_name" = 'person'), 'ORGANIZATION_TO_PERSON', 'VENDOR', NULL, NULL, NULL, NULL, NULL, NULL);
+INSERT INTO "party_relation" ("party_id", "related_party_id", "relation_type_id", "party_role_id", "created_by", "updated_at", "updated_by", "deleted_at", "deleted_by", "activity_log") VALUES ((SELECT "party_id" FROM "party" WHERE "party_type_id" = 'PERSON' AND "party_name" = 'person'), (SELECT "party_id" FROM "party" WHERE "party_type_id" = 'PERSON' AND "party_name" = 'person'), 'ORGANIZATION_TO_PERSON', (SELECT "party_role_id" FROM "party_role" WHERE "code" = 'VENDOR'), NULL, NULL, NULL, NULL, NULL, NULL);
 
 INSERT INTO "organization" ("party_id", "name", "license", "registration_date", "created_by", "updated_at", "updated_by", "deleted_at", "deleted_by", "activity_log") VALUES ((SELECT "party_id" FROM "party" WHERE "party_type_id" = 'PERSON' AND "party_name" = 'person'), 'Test Name', 'Test License', '2023-02-06', NULL, NULL, NULL, NULL, NULL, NULL);
 
 
 INSERT INTO "organization_role" ("person_id", "organization_id", "organization_role_type_id", "created_by", "updated_at", "updated_by", "deleted_at", "deleted_by", "activity_log") VALUES ((SELECT "person_id" FROM "person" WHERE "person_first_name" = 'Test First Name' AND "person_last_name" = 'Test Last Name'), (SELECT "organization_id" FROM "organization" WHERE "name" = 'Test Name'), (SELECT "organization_role_type_id" FROM "organization_role_type" WHERE "code" = 'ASSOCIATE_MANAGER_TECHNOLOGY'), NULL, NULL, NULL, NULL, NULL, NULL);
 
-INSERT INTO "contact_electronic" ("contact_type_id", "party_id", "electronics_details", "created_by", "updated_at", "updated_by", "deleted_at", "deleted_by", "activity_log") VALUES ('MOBILE_PHONE_NUMBER', (SELECT "party_id" FROM "party" WHERE "party_type_id" = 'PERSON' AND "party_name" = 'person'), 'electronics details', NULL, NULL, NULL, NULL, NULL, NULL);
+INSERT INTO "contact_electronic" ("contact_type_id", "party_id", "electronics_details", "created_by", "updated_at", "updated_by", "deleted_at", "deleted_by", "activity_log") VALUES ((SELECT "contact_type_id" FROM "contact_type" WHERE "code" = 'MOBILE_PHONE_NUMBER'), (SELECT "party_id" FROM "party" WHERE "party_type_id" = 'PERSON' AND "party_name" = 'person'), 'electronics details', NULL, NULL, NULL, NULL, NULL, NULL);

--- a/pattern/infra-assurance/models_test.ts
+++ b/pattern/infra-assurance/models_test.ts
@@ -83,14 +83,18 @@ const partyID = udm.party.select(partyInsertion.insertable);
 const partyIdentifierInsertion = udm.partyIdentifier
   .insertDML({
     identifier_number: "test identifier",
-    party_identifier_type_id: "PASSPORT",
+    party_identifier_type_id: udm.partyIdentifierType.select({
+      code: "PASSPORT",
+    }),
     party_id: partyID,
   });
 
 const personInsertion = udm.person
   .insertDML({
     party_id: partyID,
-    person_type_id: "PROFESSIONAL",
+    person_type_id: udm.personType.select({
+      code: "PROFESSIONAL",
+    }),
     person_first_name: "Test First Name",
     person_last_name: "Test Last Name",
   });
@@ -100,7 +104,9 @@ const partyRelationInsertion = udm.partyRelation
     party_id: partyID,
     related_party_id: partyID,
     relation_type_id: "ORGANIZATION_TO_PERSON",
-    party_role_id: "VENDOR",
+    party_role_id: udm.partyRole.select({
+      code: "VENDOR",
+    }),
   });
 
 const organizationInsertion = udm.organization
@@ -130,7 +136,9 @@ const organizationRoleInsertion = udm.organizationRole
 
 const contactElectronicInsertion = udm.contactElectronic
   .insertDML({
-    contact_type_id: "MOBILE_PHONE_NUMBER",
+    contact_type_id: udm.contactType.select({
+      code: "MOBILE_PHONE_NUMBER",
+    }),
     party_id: partyID,
     electronics_details: "electronics details",
   });

--- a/pattern/udm/models.ts
+++ b/pattern/udm/models.ts
@@ -32,6 +32,10 @@ export const {
   dateTime,
   selfRef,
   dateTimeNullable,
+  float,
+  floatNullable,
+  bigFloat,
+  bigFloatNullable,
 } = gm.domains;
 export const { autoIncPrimaryKey: autoIncPK } = gm.keys;
 
@@ -41,6 +45,53 @@ export const execCtx = gm.textEnumTable(
   { isIdempotent: true },
 );
 
+export const partyRole = gm.autoIncPkTable(
+  "party_role",
+  {
+    party_role_id: autoIncPK(),
+    code: tcf.unique(text()),
+    value: text(),
+    ...gm.housekeeping.columns,
+  },
+  {
+    qualitySystem: {
+      description:
+        "Entity to store different types of party roles. Each role is identified by a unique code and has an associated value/description.",
+    },
+  },
+);
+
+export const partyIdentifierType = gm.autoIncPkTable(
+  "party_identifier_type",
+  {
+    party_identifier_type_id: autoIncPK(),
+    code: tcf.unique(text()),
+    value: text(),
+    ...gm.housekeeping.columns,
+  },
+  {
+    qualitySystem: {
+      description: "Entity to store different types of party identifiers.",
+    },
+  },
+);
+
+export const contactType = gm.autoIncPkTable(
+  "contact_type",
+  {
+    contact_type_id: autoIncPK(),
+    code: tcf.unique(text()),
+    value: text(),
+    ...gm.housekeeping.columns,
+  },
+  {
+    qualitySystem: {
+      description:
+        "Entity Table to store different types of contact information.",
+    },
+  },
+);
+
 export const organizationRoleType = gm.autoIncPkTable(
   "organization_role_type",
   {
@@ -48,6 +99,12 @@ export const organizationRoleType = gm.autoIncPkTable(
     code: tcf.unique(text()),
     value: text(),
     ...gm.housekeeping.columns,
+  },
+  {
+    qualitySystem: {
+      description:
+        "Entity to store different types of organization roles. Each role is identified by a unique code and has an associated value/description.",
+    },
   },
 );
 
@@ -61,39 +118,25 @@ export const partyRoleType = gm.autoIncPkTable(
   },
 );
 
+export const personType = gm.autoIncPkTable(
+  "person_type",
+  {
+    person_type_id: autoIncPK(),
+    code: tcf.unique(text()),
+    value: text(),
+    ...gm.housekeeping.columns,
+  },
+);
+
 export const partyType = gm.textEnumTable(
   "party_type",
   govn.PartyType,
   { isIdempotent: true },
 );
 
-export const partyRole = gm.textEnumTable(
-  "party_role_type",
-  govn.PartyRole,
-  { isIdempotent: true },
-);
-
-export const partyIdentifierType = gm.textEnumTable(
-  "party_identifier_type",
-  govn.PartyIdentifierType,
-  { isIdempotent: true },
-);
-
 export const partyRelationType = gm.textEnumTable(
   "party_relation_type",
   govn.PartyRelationType,
-  { isIdempotent: true },
-);
-
-export const personType = gm.textEnumTable(
-  "person_type",
-  govn.PersonType,
-  { isIdempotent: true },
-);
-
-export const contactType = gm.textEnumTable(
-  "contact_type",
-  govn.ContactType,
   { isIdempotent: true },
 );
 
@@ -105,11 +148,7 @@ export const allReferenceTables: (
 )[] = [
   execCtx,
   partyType,
-  partyRole,
   partyRelationType,
-  partyIdentifierType,
-  personType,
-  contactType,
 ];
 
 export const party = gm.autoIncPkTable("party", {
@@ -131,9 +170,15 @@ export const party = gm.autoIncPkTable("party", {
 export const partyIdentifier = gm.autoIncPkTable("party_identifier", {
   party_identifier_id: autoIncPK(),
   identifier_number: text(),
-  party_identifier_type_id: partyIdentifierType.references.code(),
+  party_identifier_type_id: partyIdentifierType.references
+    .party_identifier_type_id(),
   party_id: party.references.party_id(),
   ...gm.housekeeping.columns,
+}, {
+  qualitySystem: {
+    description:
+      "Entity to associate identifiers with parties. Each party identifier has a unique ID and is associated with a specific party and identifier type.",
+  },
 });
 
 /**
@@ -144,12 +189,17 @@ export const partyIdentifier = gm.autoIncPkTable("party_identifier", {
 export const person = gm.autoIncPkTable("person", {
   person_id: autoIncPK(),
   party_id: party.references.party_id(),
-  person_type_id: personType.references.code(),
+  person_type_id: personType.references.person_type_id(),
   person_first_name: text(),
   person_last_name: text(),
   honorific_prefix: textNullable(),
   honorific_suffix: textNullable(),
   ...gm.housekeeping.columns,
+}, {
+  qualitySystem: {
+    description:
+      "Entity to store information about individuals as persons. Each person has a unique ID associated with them.",
+  },
 });
 
 /**
@@ -161,8 +211,13 @@ export const partyRelation = gm.autoIncPkTable("party_relation", {
   party_id: party.references.party_id(),
   related_party_id: party.references.party_id(),
   relation_type_id: partyRelationType.references.code(),
-  party_role_id: partyRole.references.code().optional(),
+  party_role_id: partyRole.references.party_role_id().optional(),
   ...gm.housekeeping.columns,
+}, {
+  qualitySystem: {
+    description:
+      "Entity to define relationships between parties. Each party relation has a unique ID associated with it.",
+  },
 });
 
 export const organization = gm.autoIncPkTable("organization", {
@@ -172,6 +227,11 @@ export const organization = gm.autoIncPkTable("organization", {
   license: text(),
   registration_date: date(),
   ...gm.housekeeping.columns,
+}, {
+  qualitySystem: {
+    description:
+      "Entity to store information about organizations. Each organization has a unique ID associated with it.",
+  },
 });
 
 export const organizationRole = gm.autoIncPkTable("organization_role", {
@@ -181,19 +241,29 @@ export const organizationRole = gm.autoIncPkTable("organization_role", {
   organization_role_type_id: organizationRoleType.references
     .organization_role_type_id(),
   ...gm.housekeeping.columns,
+}, {
+  qualitySystem: {
+    description:
+      "Entity to associate individuals with roles in organizations. Each organization role has a unique ID associated with it.",
+  },
 });
 
 export const contactElectronic = gm.autoIncPkTable("contact_electronic", {
   contact_electronic_id: autoIncPK(),
-  contact_type_id: contactType.references.code(),
+  contact_type_id: contactType.references.contact_type_id(),
   party_id: party.references.party_id(),
   electronics_details: text(),
   ...gm.housekeeping.columns,
+}, {
+  qualitySystem: {
+    description:
+      "Entity to store electronic contact information associated with parties. Each electronic contact has a unique ID associated with it.",
+  },
 });
 
 export const contactLand = gm.autoIncPkTable("contact_land", {
   contact_land_id: autoIncPK(),
-  contact_type_id: contactType.references.code(),
+  contact_type_id: contactType.references.contact_type_id(),
   party_id: party.references.party_id(),
   address_line1: text(),
   address_line2: text(),
@@ -202,6 +272,11 @@ export const contactLand = gm.autoIncPkTable("contact_land", {
   address_state: text(),
   address_country: text(),
   ...gm.housekeeping.columns,
+}, {
+  qualitySystem: {
+    description:
+      "Entity to store land-based contact information associated with parties. Each land contact has a unique ID associated with it.",
+  },
 });
 
 /**
@@ -228,6 +303,9 @@ export const allContentTables: SQLa.TableDefinition<
   typ.TypicalDomainQS
 >[] = [
   organizationRoleType,
+  partyRole,
+  partyIdentifierType,
+  contactType,
   party,
   partyIdentifier,
   person,
@@ -236,9 +314,10 @@ export const allContentTables: SQLa.TableDefinition<
   organizationRole,
   contactElectronic,
   contactLand,
+  personType,
 ];
 
-const vendorView = SQLa.safeViewDefinition(
+export const vendorView = SQLa.safeViewDefinition(
   "vendor_view",
   {
     name: text(),
@@ -259,8 +338,8 @@ const vendorView = SQLa.safeViewDefinition(
   l.address_country as country
   FROM party_relation prl
   INNER JOIN party pr ON pr.party_id = prl.party_id
-  INNER JOIN contact_electronic e ON e.party_id = pr.party_id AND e.contact_type_id = 'OFFICIAL_EMAIL'
-  INNER JOIN contact_land l ON l.party_id = pr.party_id AND l.contact_type_id = 'OFFICIAL_ADDRESS'
+  INNER JOIN contact_electronic e ON e.party_id = pr.party_id AND e.contact_type_id = (SELECT contact_type_id FROM contact_type WHERE code='OFFICIAL_EMAIL')
+  INNER JOIN contact_land l ON l.party_id = pr.party_id AND l.contact_type_id = (SELECT contact_type_id FROM contact_type WHERE code='OFFICIAL_ADDRESS')
   WHERE prl.party_role_id = 'VENDOR' AND prl.relation_type_id = 'ORGANIZATION_TO_PERSON'`;
 
 export const allContentViews: SQLa.ViewDefinition<Any, EmitContext>[] = [
@@ -279,6 +358,7 @@ export function sqlDDL() {
 
     -- content tables
     ${allContentTables}
+
 
     --content views
     ${allContentViews}

--- a/pattern/udm/models_test.fixture.puml
+++ b/pattern/udm/models_test.fixture.puml
@@ -24,6 +24,48 @@
       activity_log: TEXT
   }
 
+  entity "party_role" as party_role {
+      **party_role_id**: INTEGER
+    --
+    * code: TEXT
+    * value: TEXT
+      created_at: TIMESTAMP
+      created_by: TEXT
+      updated_at: TIMESTAMP
+      updated_by: TEXT
+      deleted_at: TIMESTAMP
+      deleted_by: TEXT
+      activity_log: TEXT
+  }
+
+  entity "party_identifier_type" as party_identifier_type {
+      **party_identifier_type_id**: INTEGER
+    --
+    * code: TEXT
+    * value: TEXT
+      created_at: TIMESTAMP
+      created_by: TEXT
+      updated_at: TIMESTAMP
+      updated_by: TEXT
+      deleted_at: TIMESTAMP
+      deleted_by: TEXT
+      activity_log: TEXT
+  }
+
+  entity "contact_type" as contact_type {
+      **contact_type_id**: INTEGER
+    --
+    * code: TEXT
+    * value: TEXT
+      created_at: TIMESTAMP
+      created_by: TEXT
+      updated_at: TIMESTAMP
+      updated_by: TEXT
+      deleted_at: TIMESTAMP
+      deleted_by: TEXT
+      activity_log: TEXT
+  }
+
   entity "party" as party {
       **party_id**: INTEGER
     --
@@ -42,7 +84,7 @@
       **party_identifier_id**: INTEGER
     --
     * identifier_number: TEXT
-    * party_identifier_type_id: TEXT
+    * party_identifier_type_id: INTEGER
     * party_id: INTEGER
       created_at: TIMESTAMP
       created_by: TEXT
@@ -57,7 +99,7 @@
       **person_id**: INTEGER
     --
     * party_id: INTEGER
-    * person_type_id: TEXT
+    * person_type_id: INTEGER
     * person_first_name: TEXT
     * person_last_name: TEXT
       honorific_prefix: TEXT
@@ -77,7 +119,7 @@
     * party_id: INTEGER
     * related_party_id: INTEGER
     * relation_type_id: TEXT
-      party_role_id: TEXT
+      party_role_id: INTEGER
       created_at: TIMESTAMP
       created_by: TEXT
       updated_at: TIMESTAMP
@@ -121,7 +163,7 @@
   entity "contact_electronic" as contact_electronic {
       **contact_electronic_id**: INTEGER
     --
-    * contact_type_id: TEXT
+    * contact_type_id: INTEGER
     * party_id: INTEGER
     * electronics_details: TEXT
       created_at: TIMESTAMP
@@ -136,7 +178,7 @@
   entity "contact_land" as contact_land {
       **contact_land_id**: INTEGER
     --
-    * contact_type_id: TEXT
+    * contact_type_id: INTEGER
     * party_id: INTEGER
     * address_line1: TEXT
     * address_line2: TEXT
@@ -153,14 +195,33 @@
       activity_log: TEXT
   }
 
+  entity "person_type" as person_type {
+      **person_type_id**: INTEGER
+    --
+    * code: TEXT
+    * value: TEXT
+      created_at: TIMESTAMP
+      created_by: TEXT
+      updated_at: TIMESTAMP
+      updated_by: TEXT
+      deleted_at: TIMESTAMP
+      deleted_by: TEXT
+      activity_log: TEXT
+  }
+
+  party_identifier_type |o..o{ party_identifier
   party |o..o{ party_identifier
   party |o..o{ person
+  person_type |o..o{ person
   party |o..o{ party_relation
   party |o..o{ party_relation
+  party_role |o..o{ party_relation
   party |o..o{ organization
   person |o..o{ organization_role
   organization |o..o{ organization_role
   organization_role_type |o..o{ organization_role
+  contact_type |o..o{ contact_electronic
   party |o..o{ contact_electronic
+  contact_type |o..o{ contact_land
   party |o..o{ contact_land
 @enduml

--- a/pattern/udm/models_test.fixture.sh
+++ b/pattern/udm/models_test.fixture.sh
@@ -45,27 +45,7 @@ CREATE TABLE IF NOT EXISTS "party_type" (
     "value" TEXT NOT NULL,
     "created_at" TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 );
-CREATE TABLE IF NOT EXISTS "party_role_type" (
-    "code" TEXT PRIMARY KEY NOT NULL,
-    "value" TEXT NOT NULL,
-    "created_at" TIMESTAMP DEFAULT CURRENT_TIMESTAMP
-);
 CREATE TABLE IF NOT EXISTS "party_relation_type" (
-    "code" TEXT PRIMARY KEY NOT NULL,
-    "value" TEXT NOT NULL,
-    "created_at" TIMESTAMP DEFAULT CURRENT_TIMESTAMP
-);
-CREATE TABLE IF NOT EXISTS "party_identifier_type" (
-    "code" TEXT PRIMARY KEY NOT NULL,
-    "value" TEXT NOT NULL,
-    "created_at" TIMESTAMP DEFAULT CURRENT_TIMESTAMP
-);
-CREATE TABLE IF NOT EXISTS "person_type" (
-    "code" TEXT PRIMARY KEY NOT NULL,
-    "value" TEXT NOT NULL,
-    "created_at" TIMESTAMP DEFAULT CURRENT_TIMESTAMP
-);
-CREATE TABLE IF NOT EXISTS "contact_type" (
     "code" TEXT PRIMARY KEY NOT NULL,
     "value" TEXT NOT NULL,
     "created_at" TIMESTAMP DEFAULT CURRENT_TIMESTAMP
@@ -74,6 +54,45 @@ CREATE TABLE IF NOT EXISTS "contact_type" (
 -- content tables
 CREATE TABLE IF NOT EXISTS "organization_role_type" (
     "organization_role_type_id" INTEGER PRIMARY KEY AUTOINCREMENT,
+    "code" TEXT /* UNIQUE COLUMN */ NOT NULL,
+    "value" TEXT NOT NULL,
+    "created_at" TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    "created_by" TEXT DEFAULT 'UNKNOWN',
+    "updated_at" TIMESTAMP,
+    "updated_by" TEXT,
+    "deleted_at" TIMESTAMP,
+    "deleted_by" TEXT,
+    "activity_log" TEXT,
+    UNIQUE("code")
+);
+CREATE TABLE IF NOT EXISTS "party_role" (
+    "party_role_id" INTEGER PRIMARY KEY AUTOINCREMENT,
+    "code" TEXT /* UNIQUE COLUMN */ NOT NULL,
+    "value" TEXT NOT NULL,
+    "created_at" TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    "created_by" TEXT DEFAULT 'UNKNOWN',
+    "updated_at" TIMESTAMP,
+    "updated_by" TEXT,
+    "deleted_at" TIMESTAMP,
+    "deleted_by" TEXT,
+    "activity_log" TEXT,
+    UNIQUE("code")
+);
+CREATE TABLE IF NOT EXISTS "party_identifier_type" (
+    "party_identifier_type_id" INTEGER PRIMARY KEY AUTOINCREMENT,
+    "code" TEXT /* UNIQUE COLUMN */ NOT NULL,
+    "value" TEXT NOT NULL,
+    "created_at" TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    "created_by" TEXT DEFAULT 'UNKNOWN',
+    "updated_at" TIMESTAMP,
+    "updated_by" TEXT,
+    "deleted_at" TIMESTAMP,
+    "deleted_by" TEXT,
+    "activity_log" TEXT,
+    UNIQUE("code")
+);
+CREATE TABLE IF NOT EXISTS "contact_type" (
+    "contact_type_id" INTEGER PRIMARY KEY AUTOINCREMENT,
     "code" TEXT /* UNIQUE COLUMN */ NOT NULL,
     "value" TEXT NOT NULL,
     "created_at" TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
@@ -101,7 +120,7 @@ CREATE TABLE IF NOT EXISTS "party" (
 CREATE TABLE IF NOT EXISTS "party_identifier" (
     "party_identifier_id" INTEGER PRIMARY KEY AUTOINCREMENT,
     "identifier_number" TEXT NOT NULL,
-    "party_identifier_type_id" TEXT NOT NULL,
+    "party_identifier_type_id" INTEGER NOT NULL,
     "party_id" INTEGER NOT NULL,
     "created_at" TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     "created_by" TEXT DEFAULT 'UNKNOWN',
@@ -110,13 +129,13 @@ CREATE TABLE IF NOT EXISTS "party_identifier" (
     "deleted_at" TIMESTAMP,
     "deleted_by" TEXT,
     "activity_log" TEXT,
-    FOREIGN KEY("party_identifier_type_id") REFERENCES "party_identifier_type"("code"),
+    FOREIGN KEY("party_identifier_type_id") REFERENCES "party_identifier_type"("party_identifier_type_id"),
     FOREIGN KEY("party_id") REFERENCES "party"("party_id")
 );
 CREATE TABLE IF NOT EXISTS "person" (
     "person_id" INTEGER PRIMARY KEY AUTOINCREMENT,
     "party_id" INTEGER NOT NULL,
-    "person_type_id" TEXT NOT NULL,
+    "person_type_id" INTEGER NOT NULL,
     "person_first_name" TEXT NOT NULL,
     "person_last_name" TEXT NOT NULL,
     "honorific_prefix" TEXT,
@@ -129,14 +148,14 @@ CREATE TABLE IF NOT EXISTS "person" (
     "deleted_by" TEXT,
     "activity_log" TEXT,
     FOREIGN KEY("party_id") REFERENCES "party"("party_id"),
-    FOREIGN KEY("person_type_id") REFERENCES "person_type"("code")
+    FOREIGN KEY("person_type_id") REFERENCES "person_type"("person_type_id")
 );
 CREATE TABLE IF NOT EXISTS "party_relation" (
     "party_relation_id" INTEGER PRIMARY KEY AUTOINCREMENT,
     "party_id" INTEGER NOT NULL,
     "related_party_id" INTEGER NOT NULL,
     "relation_type_id" TEXT NOT NULL,
-    "party_role_id" TEXT,
+    "party_role_id" INTEGER,
     "created_at" TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     "created_by" TEXT DEFAULT 'UNKNOWN',
     "updated_at" TIMESTAMP,
@@ -147,7 +166,7 @@ CREATE TABLE IF NOT EXISTS "party_relation" (
     FOREIGN KEY("party_id") REFERENCES "party"("party_id"),
     FOREIGN KEY("related_party_id") REFERENCES "party"("party_id"),
     FOREIGN KEY("relation_type_id") REFERENCES "party_relation_type"("code"),
-    FOREIGN KEY("party_role_id") REFERENCES "party_role_type"("code")
+    FOREIGN KEY("party_role_id") REFERENCES "party_role"("party_role_id")
 );
 CREATE TABLE IF NOT EXISTS "organization" (
     "organization_id" INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -182,7 +201,7 @@ CREATE TABLE IF NOT EXISTS "organization_role" (
 );
 CREATE TABLE IF NOT EXISTS "contact_electronic" (
     "contact_electronic_id" INTEGER PRIMARY KEY AUTOINCREMENT,
-    "contact_type_id" TEXT NOT NULL,
+    "contact_type_id" INTEGER NOT NULL,
     "party_id" INTEGER NOT NULL,
     "electronics_details" TEXT NOT NULL,
     "created_at" TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
@@ -192,12 +211,12 @@ CREATE TABLE IF NOT EXISTS "contact_electronic" (
     "deleted_at" TIMESTAMP,
     "deleted_by" TEXT,
     "activity_log" TEXT,
-    FOREIGN KEY("contact_type_id") REFERENCES "contact_type"("code"),
+    FOREIGN KEY("contact_type_id") REFERENCES "contact_type"("contact_type_id"),
     FOREIGN KEY("party_id") REFERENCES "party"("party_id")
 );
 CREATE TABLE IF NOT EXISTS "contact_land" (
     "contact_land_id" INTEGER PRIMARY KEY AUTOINCREMENT,
-    "contact_type_id" TEXT NOT NULL,
+    "contact_type_id" INTEGER NOT NULL,
     "party_id" INTEGER NOT NULL,
     "address_line1" TEXT NOT NULL,
     "address_line2" TEXT NOT NULL,
@@ -212,9 +231,23 @@ CREATE TABLE IF NOT EXISTS "contact_land" (
     "deleted_at" TIMESTAMP,
     "deleted_by" TEXT,
     "activity_log" TEXT,
-    FOREIGN KEY("contact_type_id") REFERENCES "contact_type"("code"),
+    FOREIGN KEY("contact_type_id") REFERENCES "contact_type"("contact_type_id"),
     FOREIGN KEY("party_id") REFERENCES "party"("party_id")
 );
+CREATE TABLE IF NOT EXISTS "person_type" (
+    "person_type_id" INTEGER PRIMARY KEY AUTOINCREMENT,
+    "code" TEXT /* UNIQUE COLUMN */ NOT NULL,
+    "value" TEXT NOT NULL,
+    "created_at" TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    "created_by" TEXT DEFAULT 'UNKNOWN',
+    "updated_at" TIMESTAMP,
+    "updated_by" TEXT,
+    "deleted_at" TIMESTAMP,
+    "deleted_by" TEXT,
+    "activity_log" TEXT,
+    UNIQUE("code")
+);
+
 
 --content views
 CREATE VIEW IF NOT EXISTS "vendor_view"("name", "email", "address", "state", "city", "zip", "country") AS
@@ -227,8 +260,8 @@ CREATE VIEW IF NOT EXISTS "vendor_view"("name", "email", "address", "state", "ci
     l.address_country as country
     FROM party_relation prl
     INNER JOIN party pr ON pr.party_id = prl.party_id
-    INNER JOIN contact_electronic e ON e.party_id = pr.party_id AND e.contact_type_id = 'OFFICIAL_EMAIL'
-    INNER JOIN contact_land l ON l.party_id = pr.party_id AND l.contact_type_id = 'OFFICIAL_ADDRESS'
+    INNER JOIN contact_electronic e ON e.party_id = pr.party_id AND e.contact_type_id = (SELECT contact_type_id FROM contact_type WHERE code='OFFICIAL_EMAIL')
+    INNER JOIN contact_land l ON l.party_id = pr.party_id AND l.contact_type_id = (SELECT contact_type_id FROM contact_type WHERE code='OFFICIAL_ADDRESS')
     WHERE prl.party_role_id = 'VENDOR' AND prl.relation_type_id = 'ORGANIZATION_TO_PERSON';
 
 -- seed Data
@@ -239,41 +272,45 @@ INSERT INTO "execution_context" ("code", "value") VALUES ('SANDBOX', 'sandbox');
 INSERT INTO "execution_context" ("code", "value") VALUES ('EXPERIMENTAL', 'experimental');
 INSERT INTO "party_type" ("code", "value") VALUES ('PERSON', 'Person');
 INSERT INTO "party_type" ("code", "value") VALUES ('ORGANIZATION', 'Organization');
-INSERT INTO "party_role_type" ("code", "value") VALUES ('CUSTOMER', 'Customer');
-INSERT INTO "party_role_type" ("code", "value") VALUES ('VENDOR', 'Vendor');
 INSERT INTO "party_relation_type" ("code", "value") VALUES ('PERSON_TO_PERSON', 'Person To Person');
 INSERT INTO "party_relation_type" ("code", "value") VALUES ('ORGANIZATION_TO_PERSON', 'Organization To Person');
 INSERT INTO "party_relation_type" ("code", "value") VALUES ('ORGANIZATION_TO_ORGANIZATION', 'Organization To Organization');
-INSERT INTO "party_identifier_type" ("code", "value") VALUES ('UUID', 'UUID');
-INSERT INTO "party_identifier_type" ("code", "value") VALUES ('DRIVING_LICENSE', 'Driving License');
-INSERT INTO "party_identifier_type" ("code", "value") VALUES ('PASSPORT', 'Passport');
-INSERT INTO "person_type" ("code", "value") VALUES ('INDIVIDUAL', 'Individual');
-INSERT INTO "person_type" ("code", "value") VALUES ('PROFESSIONAL', 'Professional');
-INSERT INTO "contact_type" ("code", "value") VALUES ('HOME_ADDRESS', 'Home Address');
-INSERT INTO "contact_type" ("code", "value") VALUES ('OFFICIAL_ADDRESS', 'Official Address');
-INSERT INTO "contact_type" ("code", "value") VALUES ('MOBILE_PHONE_NUMBER', 'Mobile Phone Number');
-INSERT INTO "contact_type" ("code", "value") VALUES ('LAND_PHONE_NUMBER', 'Land Phone Number');
-INSERT INTO "contact_type" ("code", "value") VALUES ('OFFICIAL_EMAIL', 'Official Email');
-INSERT INTO "contact_type" ("code", "value") VALUES ('PERSONAL_EMAIL', 'Personal Email');
 ;
 
 -- synthetic / test data
 
+INSERT INTO "party_role" ("code", "value", "created_by", "updated_at", "updated_by", "deleted_at", "deleted_by", "activity_log")
+       VALUES ('VENDOR', 'Vendor', NULL, NULL, NULL, NULL, NULL, NULL),
+              ('CUSTOMER', 'Customer', NULL, NULL, NULL, NULL, NULL, NULL);
 INSERT INTO "party" ("party_type_id", "party_name", "created_by", "updated_at", "updated_by", "deleted_at", "deleted_by", "activity_log") VALUES ('PERSON', 'person', NULL, NULL, NULL, NULL, NULL, NULL);
+INSERT INTO "person_type" ("code", "value", "created_by", "updated_at", "updated_by", "deleted_at", "deleted_by", "activity_log")
+       VALUES ('INDIVIDUAL', 'Individual', NULL, NULL, NULL, NULL, NULL, NULL),
+              ('PROFESSIONAL', 'Professional', NULL, NULL, NULL, NULL, NULL, NULL);
+INSERT INTO "party_identifier_type" ("code", "value", "created_by", "updated_at", "updated_by", "deleted_at", "deleted_by", "activity_log")
+       VALUES ('PASSPORT', 'Passport', NULL, NULL, NULL, NULL, NULL, NULL),
+              ('UUID', 'UUID', NULL, NULL, NULL, NULL, NULL, NULL),
+              ('DRIVING_LICENSE', 'Driving License', NULL, NULL, NULL, NULL, NULL, NULL);
 
-INSERT INTO "party_identifier" ("identifier_number", "party_identifier_type_id", "party_id", "created_by", "updated_at", "updated_by", "deleted_at", "deleted_by", "activity_log") VALUES ('test identifier', 'PASSPORT', (SELECT "party_id" FROM "party" WHERE "party_type_id" = 'PERSON' AND "party_name" = 'person'), NULL, NULL, NULL, NULL, NULL, NULL);
+INSERT INTO "party_identifier" ("identifier_number", "party_identifier_type_id", "party_id", "created_by", "updated_at", "updated_by", "deleted_at", "deleted_by", "activity_log") VALUES ('test identifier', (SELECT "party_identifier_type_id" FROM "party_identifier_type" WHERE "code" = 'PASSPORT'), (SELECT "party_id" FROM "party" WHERE "party_type_id" = 'PERSON'), NULL, NULL, NULL, NULL, NULL, NULL);
 
-INSERT INTO "person" ("party_id", "person_type_id", "person_first_name", "person_last_name", "honorific_prefix", "honorific_suffix", "created_by", "updated_at", "updated_by", "deleted_at", "deleted_by", "activity_log") VALUES ((SELECT "party_id" FROM "party" WHERE "party_type_id" = 'PERSON' AND "party_name" = 'person'), 'PROFESSIONAL', 'Test First Name', 'Test Last Name', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+INSERT INTO "person" ("party_id", "person_type_id", "person_first_name", "person_last_name", "honorific_prefix", "honorific_suffix", "created_by", "updated_at", "updated_by", "deleted_at", "deleted_by", "activity_log") VALUES ((SELECT "party_id" FROM "party" WHERE "party_type_id" = 'PERSON'), (SELECT "person_type_id" FROM "person_type" WHERE "code" = 'PROFESSIONAL'), 'Test First Name', 'Test Last Name', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
-INSERT INTO "party_relation" ("party_id", "related_party_id", "relation_type_id", "party_role_id", "created_by", "updated_at", "updated_by", "deleted_at", "deleted_by", "activity_log") VALUES ((SELECT "party_id" FROM "party" WHERE "party_type_id" = 'PERSON' AND "party_name" = 'person'), (SELECT "party_id" FROM "party" WHERE "party_type_id" = 'PERSON' AND "party_name" = 'person'), 'ORGANIZATION_TO_PERSON', 'VENDOR', NULL, NULL, NULL, NULL, NULL, NULL);
+INSERT INTO "party_relation" ("party_id", "related_party_id", "relation_type_id", "party_role_id", "created_by", "updated_at", "updated_by", "deleted_at", "deleted_by", "activity_log") VALUES ((SELECT "party_id" FROM "party" WHERE "party_type_id" = 'PERSON'), (SELECT "party_id" FROM "party" WHERE "party_type_id" = 'PERSON'), 'ORGANIZATION_TO_PERSON', (SELECT "party_role_id" FROM "party_role" WHERE "code" = 'VENDOR'), NULL, NULL, NULL, NULL, NULL, NULL);
 
-INSERT INTO "organization" ("party_id", "name", "license", "registration_date", "created_by", "updated_at", "updated_by", "deleted_at", "deleted_by", "activity_log") VALUES ((SELECT "party_id" FROM "party" WHERE "party_type_id" = 'PERSON' AND "party_name" = 'person'), 'Test Name', 'Test License', '2023-02-06', NULL, NULL, NULL, NULL, NULL, NULL);
+INSERT INTO "organization" ("party_id", "name", "license", "registration_date", "created_by", "updated_at", "updated_by", "deleted_at", "deleted_by", "activity_log") VALUES ((SELECT "party_id" FROM "party" WHERE "party_type_id" = 'PERSON'), 'Test Name', 'Test License', '2023-02-06', NULL, NULL, NULL, NULL, NULL, NULL);
 
 INSERT INTO "organization_role_type" ("code", "value", "created_by", "updated_at", "updated_by", "deleted_at", "deleted_by", "activity_log") VALUES ('ASSOCIATE_MANAGER_TECHNOLOGY', 'Associate Manager Technology', NULL, NULL, NULL, NULL, NULL, NULL);
 
 INSERT INTO "organization_role" ("person_id", "organization_id", "organization_role_type_id", "created_by", "updated_at", "updated_by", "deleted_at", "deleted_by", "activity_log") VALUES ((SELECT "person_id" FROM "person" WHERE "person_first_name" = 'Test First Name' AND "person_last_name" = 'Test Last Name'), (SELECT "organization_id" FROM "organization" WHERE "name" = 'Test Name'), (SELECT "organization_role_type_id" FROM "organization_role_type" WHERE "code" = 'ASSOCIATE_MANAGER_TECHNOLOGY'), NULL, NULL, NULL, NULL, NULL, NULL);
 
-INSERT INTO "contact_electronic" ("contact_type_id", "party_id", "electronics_details", "created_by", "updated_at", "updated_by", "deleted_at", "deleted_by", "activity_log") VALUES ('MOBILE_PHONE_NUMBER', (SELECT "party_id" FROM "party" WHERE "party_type_id" = 'PERSON' AND "party_name" = 'person'), 'electronics details', NULL, NULL, NULL, NULL, NULL, NULL);
+INSERT INTO "contact_type" ("code", "value", "created_by", "updated_at", "updated_by", "deleted_at", "deleted_by", "activity_log")
+       VALUES ('HOME_ADDRESS', 'Home Address', NULL, NULL, NULL, NULL, NULL, NULL),
+              ('OFFICIAL_ADDRESS', 'Official Address', NULL, NULL, NULL, NULL, NULL, NULL),
+              ('MOBILE_PHONE_NUMBER', 'Mobile Phone Number', NULL, NULL, NULL, NULL, NULL, NULL),
+              ('LAND_PHONE_NUMBER', 'Land Phone Number', NULL, NULL, NULL, NULL, NULL, NULL),
+              ('OFFICIAL_EMAIL', 'Official Email', NULL, NULL, NULL, NULL, NULL, NULL),
+              ('PERSONAL_EMAIL', 'Personal Email', NULL, NULL, NULL, NULL, NULL, NULL);
+INSERT INTO "contact_electronic" ("contact_type_id", "party_id", "electronics_details", "created_by", "updated_at", "updated_by", "deleted_at", "deleted_by", "activity_log") VALUES ((SELECT "contact_type_id" FROM "contact_type" WHERE "code" = 'MOBILE_PHONE_NUMBER'), (SELECT "party_id" FROM "party" WHERE "party_type_id" = 'PERSON'), 'electronics details', NULL, NULL, NULL, NULL, NULL, NULL);
 
 -- the .dump in the last line is necessary because we load into :memory:
 -- first because performance is better and then emit all the SQL for saving

--- a/pattern/udm/models_test.fixture.sql
+++ b/pattern/udm/models_test.fixture.sql
@@ -11,27 +11,7 @@ CREATE TABLE IF NOT EXISTS "party_type" (
     "value" TEXT NOT NULL,
     "created_at" TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 );
-CREATE TABLE IF NOT EXISTS "party_role_type" (
-    "code" TEXT PRIMARY KEY NOT NULL,
-    "value" TEXT NOT NULL,
-    "created_at" TIMESTAMP DEFAULT CURRENT_TIMESTAMP
-);
 CREATE TABLE IF NOT EXISTS "party_relation_type" (
-    "code" TEXT PRIMARY KEY NOT NULL,
-    "value" TEXT NOT NULL,
-    "created_at" TIMESTAMP DEFAULT CURRENT_TIMESTAMP
-);
-CREATE TABLE IF NOT EXISTS "party_identifier_type" (
-    "code" TEXT PRIMARY KEY NOT NULL,
-    "value" TEXT NOT NULL,
-    "created_at" TIMESTAMP DEFAULT CURRENT_TIMESTAMP
-);
-CREATE TABLE IF NOT EXISTS "person_type" (
-    "code" TEXT PRIMARY KEY NOT NULL,
-    "value" TEXT NOT NULL,
-    "created_at" TIMESTAMP DEFAULT CURRENT_TIMESTAMP
-);
-CREATE TABLE IF NOT EXISTS "contact_type" (
     "code" TEXT PRIMARY KEY NOT NULL,
     "value" TEXT NOT NULL,
     "created_at" TIMESTAMP DEFAULT CURRENT_TIMESTAMP
@@ -40,6 +20,45 @@ CREATE TABLE IF NOT EXISTS "contact_type" (
 -- content tables
 CREATE TABLE IF NOT EXISTS "organization_role_type" (
     "organization_role_type_id" INTEGER PRIMARY KEY AUTOINCREMENT,
+    "code" TEXT /* UNIQUE COLUMN */ NOT NULL,
+    "value" TEXT NOT NULL,
+    "created_at" TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    "created_by" TEXT DEFAULT 'UNKNOWN',
+    "updated_at" TIMESTAMP,
+    "updated_by" TEXT,
+    "deleted_at" TIMESTAMP,
+    "deleted_by" TEXT,
+    "activity_log" TEXT,
+    UNIQUE("code")
+);
+CREATE TABLE IF NOT EXISTS "party_role" (
+    "party_role_id" INTEGER PRIMARY KEY AUTOINCREMENT,
+    "code" TEXT /* UNIQUE COLUMN */ NOT NULL,
+    "value" TEXT NOT NULL,
+    "created_at" TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    "created_by" TEXT DEFAULT 'UNKNOWN',
+    "updated_at" TIMESTAMP,
+    "updated_by" TEXT,
+    "deleted_at" TIMESTAMP,
+    "deleted_by" TEXT,
+    "activity_log" TEXT,
+    UNIQUE("code")
+);
+CREATE TABLE IF NOT EXISTS "party_identifier_type" (
+    "party_identifier_type_id" INTEGER PRIMARY KEY AUTOINCREMENT,
+    "code" TEXT /* UNIQUE COLUMN */ NOT NULL,
+    "value" TEXT NOT NULL,
+    "created_at" TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    "created_by" TEXT DEFAULT 'UNKNOWN',
+    "updated_at" TIMESTAMP,
+    "updated_by" TEXT,
+    "deleted_at" TIMESTAMP,
+    "deleted_by" TEXT,
+    "activity_log" TEXT,
+    UNIQUE("code")
+);
+CREATE TABLE IF NOT EXISTS "contact_type" (
+    "contact_type_id" INTEGER PRIMARY KEY AUTOINCREMENT,
     "code" TEXT /* UNIQUE COLUMN */ NOT NULL,
     "value" TEXT NOT NULL,
     "created_at" TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
@@ -67,7 +86,7 @@ CREATE TABLE IF NOT EXISTS "party" (
 CREATE TABLE IF NOT EXISTS "party_identifier" (
     "party_identifier_id" INTEGER PRIMARY KEY AUTOINCREMENT,
     "identifier_number" TEXT NOT NULL,
-    "party_identifier_type_id" TEXT NOT NULL,
+    "party_identifier_type_id" INTEGER NOT NULL,
     "party_id" INTEGER NOT NULL,
     "created_at" TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     "created_by" TEXT DEFAULT 'UNKNOWN',
@@ -76,13 +95,13 @@ CREATE TABLE IF NOT EXISTS "party_identifier" (
     "deleted_at" TIMESTAMP,
     "deleted_by" TEXT,
     "activity_log" TEXT,
-    FOREIGN KEY("party_identifier_type_id") REFERENCES "party_identifier_type"("code"),
+    FOREIGN KEY("party_identifier_type_id") REFERENCES "party_identifier_type"("party_identifier_type_id"),
     FOREIGN KEY("party_id") REFERENCES "party"("party_id")
 );
 CREATE TABLE IF NOT EXISTS "person" (
     "person_id" INTEGER PRIMARY KEY AUTOINCREMENT,
     "party_id" INTEGER NOT NULL,
-    "person_type_id" TEXT NOT NULL,
+    "person_type_id" INTEGER NOT NULL,
     "person_first_name" TEXT NOT NULL,
     "person_last_name" TEXT NOT NULL,
     "honorific_prefix" TEXT,
@@ -95,14 +114,14 @@ CREATE TABLE IF NOT EXISTS "person" (
     "deleted_by" TEXT,
     "activity_log" TEXT,
     FOREIGN KEY("party_id") REFERENCES "party"("party_id"),
-    FOREIGN KEY("person_type_id") REFERENCES "person_type"("code")
+    FOREIGN KEY("person_type_id") REFERENCES "person_type"("person_type_id")
 );
 CREATE TABLE IF NOT EXISTS "party_relation" (
     "party_relation_id" INTEGER PRIMARY KEY AUTOINCREMENT,
     "party_id" INTEGER NOT NULL,
     "related_party_id" INTEGER NOT NULL,
     "relation_type_id" TEXT NOT NULL,
-    "party_role_id" TEXT,
+    "party_role_id" INTEGER,
     "created_at" TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     "created_by" TEXT DEFAULT 'UNKNOWN',
     "updated_at" TIMESTAMP,
@@ -113,7 +132,7 @@ CREATE TABLE IF NOT EXISTS "party_relation" (
     FOREIGN KEY("party_id") REFERENCES "party"("party_id"),
     FOREIGN KEY("related_party_id") REFERENCES "party"("party_id"),
     FOREIGN KEY("relation_type_id") REFERENCES "party_relation_type"("code"),
-    FOREIGN KEY("party_role_id") REFERENCES "party_role_type"("code")
+    FOREIGN KEY("party_role_id") REFERENCES "party_role"("party_role_id")
 );
 CREATE TABLE IF NOT EXISTS "organization" (
     "organization_id" INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -148,7 +167,7 @@ CREATE TABLE IF NOT EXISTS "organization_role" (
 );
 CREATE TABLE IF NOT EXISTS "contact_electronic" (
     "contact_electronic_id" INTEGER PRIMARY KEY AUTOINCREMENT,
-    "contact_type_id" TEXT NOT NULL,
+    "contact_type_id" INTEGER NOT NULL,
     "party_id" INTEGER NOT NULL,
     "electronics_details" TEXT NOT NULL,
     "created_at" TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
@@ -158,12 +177,12 @@ CREATE TABLE IF NOT EXISTS "contact_electronic" (
     "deleted_at" TIMESTAMP,
     "deleted_by" TEXT,
     "activity_log" TEXT,
-    FOREIGN KEY("contact_type_id") REFERENCES "contact_type"("code"),
+    FOREIGN KEY("contact_type_id") REFERENCES "contact_type"("contact_type_id"),
     FOREIGN KEY("party_id") REFERENCES "party"("party_id")
 );
 CREATE TABLE IF NOT EXISTS "contact_land" (
     "contact_land_id" INTEGER PRIMARY KEY AUTOINCREMENT,
-    "contact_type_id" TEXT NOT NULL,
+    "contact_type_id" INTEGER NOT NULL,
     "party_id" INTEGER NOT NULL,
     "address_line1" TEXT NOT NULL,
     "address_line2" TEXT NOT NULL,
@@ -178,9 +197,23 @@ CREATE TABLE IF NOT EXISTS "contact_land" (
     "deleted_at" TIMESTAMP,
     "deleted_by" TEXT,
     "activity_log" TEXT,
-    FOREIGN KEY("contact_type_id") REFERENCES "contact_type"("code"),
+    FOREIGN KEY("contact_type_id") REFERENCES "contact_type"("contact_type_id"),
     FOREIGN KEY("party_id") REFERENCES "party"("party_id")
 );
+CREATE TABLE IF NOT EXISTS "person_type" (
+    "person_type_id" INTEGER PRIMARY KEY AUTOINCREMENT,
+    "code" TEXT /* UNIQUE COLUMN */ NOT NULL,
+    "value" TEXT NOT NULL,
+    "created_at" TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    "created_by" TEXT DEFAULT 'UNKNOWN',
+    "updated_at" TIMESTAMP,
+    "updated_by" TEXT,
+    "deleted_at" TIMESTAMP,
+    "deleted_by" TEXT,
+    "activity_log" TEXT,
+    UNIQUE("code")
+);
+
 
 --content views
 CREATE VIEW IF NOT EXISTS "vendor_view"("name", "email", "address", "state", "city", "zip", "country") AS
@@ -193,8 +226,8 @@ CREATE VIEW IF NOT EXISTS "vendor_view"("name", "email", "address", "state", "ci
     l.address_country as country
     FROM party_relation prl
     INNER JOIN party pr ON pr.party_id = prl.party_id
-    INNER JOIN contact_electronic e ON e.party_id = pr.party_id AND e.contact_type_id = 'OFFICIAL_EMAIL'
-    INNER JOIN contact_land l ON l.party_id = pr.party_id AND l.contact_type_id = 'OFFICIAL_ADDRESS'
+    INNER JOIN contact_electronic e ON e.party_id = pr.party_id AND e.contact_type_id = (SELECT contact_type_id FROM contact_type WHERE code='OFFICIAL_EMAIL')
+    INNER JOIN contact_land l ON l.party_id = pr.party_id AND l.contact_type_id = (SELECT contact_type_id FROM contact_type WHERE code='OFFICIAL_ADDRESS')
     WHERE prl.party_role_id = 'VENDOR' AND prl.relation_type_id = 'ORGANIZATION_TO_PERSON';
 
 -- seed Data
@@ -205,38 +238,42 @@ INSERT INTO "execution_context" ("code", "value") VALUES ('SANDBOX', 'sandbox');
 INSERT INTO "execution_context" ("code", "value") VALUES ('EXPERIMENTAL', 'experimental');
 INSERT INTO "party_type" ("code", "value") VALUES ('PERSON', 'Person');
 INSERT INTO "party_type" ("code", "value") VALUES ('ORGANIZATION', 'Organization');
-INSERT INTO "party_role_type" ("code", "value") VALUES ('CUSTOMER', 'Customer');
-INSERT INTO "party_role_type" ("code", "value") VALUES ('VENDOR', 'Vendor');
 INSERT INTO "party_relation_type" ("code", "value") VALUES ('PERSON_TO_PERSON', 'Person To Person');
 INSERT INTO "party_relation_type" ("code", "value") VALUES ('ORGANIZATION_TO_PERSON', 'Organization To Person');
 INSERT INTO "party_relation_type" ("code", "value") VALUES ('ORGANIZATION_TO_ORGANIZATION', 'Organization To Organization');
-INSERT INTO "party_identifier_type" ("code", "value") VALUES ('UUID', 'UUID');
-INSERT INTO "party_identifier_type" ("code", "value") VALUES ('DRIVING_LICENSE', 'Driving License');
-INSERT INTO "party_identifier_type" ("code", "value") VALUES ('PASSPORT', 'Passport');
-INSERT INTO "person_type" ("code", "value") VALUES ('INDIVIDUAL', 'Individual');
-INSERT INTO "person_type" ("code", "value") VALUES ('PROFESSIONAL', 'Professional');
-INSERT INTO "contact_type" ("code", "value") VALUES ('HOME_ADDRESS', 'Home Address');
-INSERT INTO "contact_type" ("code", "value") VALUES ('OFFICIAL_ADDRESS', 'Official Address');
-INSERT INTO "contact_type" ("code", "value") VALUES ('MOBILE_PHONE_NUMBER', 'Mobile Phone Number');
-INSERT INTO "contact_type" ("code", "value") VALUES ('LAND_PHONE_NUMBER', 'Land Phone Number');
-INSERT INTO "contact_type" ("code", "value") VALUES ('OFFICIAL_EMAIL', 'Official Email');
-INSERT INTO "contact_type" ("code", "value") VALUES ('PERSONAL_EMAIL', 'Personal Email');
 ;
 
 -- synthetic / test data
 
+INSERT INTO "party_role" ("code", "value", "created_by", "updated_at", "updated_by", "deleted_at", "deleted_by", "activity_log")
+       VALUES ('VENDOR', 'Vendor', NULL, NULL, NULL, NULL, NULL, NULL),
+              ('CUSTOMER', 'Customer', NULL, NULL, NULL, NULL, NULL, NULL);
 INSERT INTO "party" ("party_type_id", "party_name", "created_by", "updated_at", "updated_by", "deleted_at", "deleted_by", "activity_log") VALUES ('PERSON', 'person', NULL, NULL, NULL, NULL, NULL, NULL);
+INSERT INTO "person_type" ("code", "value", "created_by", "updated_at", "updated_by", "deleted_at", "deleted_by", "activity_log")
+       VALUES ('INDIVIDUAL', 'Individual', NULL, NULL, NULL, NULL, NULL, NULL),
+              ('PROFESSIONAL', 'Professional', NULL, NULL, NULL, NULL, NULL, NULL);
+INSERT INTO "party_identifier_type" ("code", "value", "created_by", "updated_at", "updated_by", "deleted_at", "deleted_by", "activity_log")
+       VALUES ('PASSPORT', 'Passport', NULL, NULL, NULL, NULL, NULL, NULL),
+              ('UUID', 'UUID', NULL, NULL, NULL, NULL, NULL, NULL),
+              ('DRIVING_LICENSE', 'Driving License', NULL, NULL, NULL, NULL, NULL, NULL);
 
-INSERT INTO "party_identifier" ("identifier_number", "party_identifier_type_id", "party_id", "created_by", "updated_at", "updated_by", "deleted_at", "deleted_by", "activity_log") VALUES ('test identifier', 'PASSPORT', (SELECT "party_id" FROM "party" WHERE "party_type_id" = 'PERSON' AND "party_name" = 'person'), NULL, NULL, NULL, NULL, NULL, NULL);
+INSERT INTO "party_identifier" ("identifier_number", "party_identifier_type_id", "party_id", "created_by", "updated_at", "updated_by", "deleted_at", "deleted_by", "activity_log") VALUES ('test identifier', (SELECT "party_identifier_type_id" FROM "party_identifier_type" WHERE "code" = 'PASSPORT'), (SELECT "party_id" FROM "party" WHERE "party_type_id" = 'PERSON'), NULL, NULL, NULL, NULL, NULL, NULL);
 
-INSERT INTO "person" ("party_id", "person_type_id", "person_first_name", "person_last_name", "honorific_prefix", "honorific_suffix", "created_by", "updated_at", "updated_by", "deleted_at", "deleted_by", "activity_log") VALUES ((SELECT "party_id" FROM "party" WHERE "party_type_id" = 'PERSON' AND "party_name" = 'person'), 'PROFESSIONAL', 'Test First Name', 'Test Last Name', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+INSERT INTO "person" ("party_id", "person_type_id", "person_first_name", "person_last_name", "honorific_prefix", "honorific_suffix", "created_by", "updated_at", "updated_by", "deleted_at", "deleted_by", "activity_log") VALUES ((SELECT "party_id" FROM "party" WHERE "party_type_id" = 'PERSON'), (SELECT "person_type_id" FROM "person_type" WHERE "code" = 'PROFESSIONAL'), 'Test First Name', 'Test Last Name', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
-INSERT INTO "party_relation" ("party_id", "related_party_id", "relation_type_id", "party_role_id", "created_by", "updated_at", "updated_by", "deleted_at", "deleted_by", "activity_log") VALUES ((SELECT "party_id" FROM "party" WHERE "party_type_id" = 'PERSON' AND "party_name" = 'person'), (SELECT "party_id" FROM "party" WHERE "party_type_id" = 'PERSON' AND "party_name" = 'person'), 'ORGANIZATION_TO_PERSON', 'VENDOR', NULL, NULL, NULL, NULL, NULL, NULL);
+INSERT INTO "party_relation" ("party_id", "related_party_id", "relation_type_id", "party_role_id", "created_by", "updated_at", "updated_by", "deleted_at", "deleted_by", "activity_log") VALUES ((SELECT "party_id" FROM "party" WHERE "party_type_id" = 'PERSON'), (SELECT "party_id" FROM "party" WHERE "party_type_id" = 'PERSON'), 'ORGANIZATION_TO_PERSON', (SELECT "party_role_id" FROM "party_role" WHERE "code" = 'VENDOR'), NULL, NULL, NULL, NULL, NULL, NULL);
 
-INSERT INTO "organization" ("party_id", "name", "license", "registration_date", "created_by", "updated_at", "updated_by", "deleted_at", "deleted_by", "activity_log") VALUES ((SELECT "party_id" FROM "party" WHERE "party_type_id" = 'PERSON' AND "party_name" = 'person'), 'Test Name', 'Test License', '2023-02-06', NULL, NULL, NULL, NULL, NULL, NULL);
+INSERT INTO "organization" ("party_id", "name", "license", "registration_date", "created_by", "updated_at", "updated_by", "deleted_at", "deleted_by", "activity_log") VALUES ((SELECT "party_id" FROM "party" WHERE "party_type_id" = 'PERSON'), 'Test Name', 'Test License', '2023-02-06', NULL, NULL, NULL, NULL, NULL, NULL);
 
 INSERT INTO "organization_role_type" ("code", "value", "created_by", "updated_at", "updated_by", "deleted_at", "deleted_by", "activity_log") VALUES ('ASSOCIATE_MANAGER_TECHNOLOGY', 'Associate Manager Technology', NULL, NULL, NULL, NULL, NULL, NULL);
 
 INSERT INTO "organization_role" ("person_id", "organization_id", "organization_role_type_id", "created_by", "updated_at", "updated_by", "deleted_at", "deleted_by", "activity_log") VALUES ((SELECT "person_id" FROM "person" WHERE "person_first_name" = 'Test First Name' AND "person_last_name" = 'Test Last Name'), (SELECT "organization_id" FROM "organization" WHERE "name" = 'Test Name'), (SELECT "organization_role_type_id" FROM "organization_role_type" WHERE "code" = 'ASSOCIATE_MANAGER_TECHNOLOGY'), NULL, NULL, NULL, NULL, NULL, NULL);
 
-INSERT INTO "contact_electronic" ("contact_type_id", "party_id", "electronics_details", "created_by", "updated_at", "updated_by", "deleted_at", "deleted_by", "activity_log") VALUES ('MOBILE_PHONE_NUMBER', (SELECT "party_id" FROM "party" WHERE "party_type_id" = 'PERSON' AND "party_name" = 'person'), 'electronics details', NULL, NULL, NULL, NULL, NULL, NULL);
+INSERT INTO "contact_type" ("code", "value", "created_by", "updated_at", "updated_by", "deleted_at", "deleted_by", "activity_log")
+       VALUES ('HOME_ADDRESS', 'Home Address', NULL, NULL, NULL, NULL, NULL, NULL),
+              ('OFFICIAL_ADDRESS', 'Official Address', NULL, NULL, NULL, NULL, NULL, NULL),
+              ('MOBILE_PHONE_NUMBER', 'Mobile Phone Number', NULL, NULL, NULL, NULL, NULL, NULL),
+              ('LAND_PHONE_NUMBER', 'Land Phone Number', NULL, NULL, NULL, NULL, NULL, NULL),
+              ('OFFICIAL_EMAIL', 'Official Email', NULL, NULL, NULL, NULL, NULL, NULL),
+              ('PERSONAL_EMAIL', 'Personal Email', NULL, NULL, NULL, NULL, NULL, NULL);
+INSERT INTO "contact_electronic" ("contact_type_id", "party_id", "electronics_details", "created_by", "updated_at", "updated_by", "deleted_at", "deleted_by", "activity_log") VALUES ((SELECT "contact_type_id" FROM "contact_type" WHERE "code" = 'MOBILE_PHONE_NUMBER'), (SELECT "party_id" FROM "party" WHERE "party_type_id" = 'PERSON'), 'electronics details', NULL, NULL, NULL, NULL, NULL, NULL);

--- a/pattern/udm/models_test.ts
+++ b/pattern/udm/models_test.ts
@@ -31,29 +31,68 @@ const partyInsertion = mod.party
     party_name: "person",
   });
 
-const partyID = mod.party.select(partyInsertion.insertable);
+const partyID = mod.party.select({ party_type_id: "PERSON" });
+
+const partyIdentifierType = mod.partyIdentifierType
+  .insertDML([{
+    code: "PASSPORT",
+    value: "Passport",
+  }, {
+    code: "UUID",
+    value: "UUID",
+  }, {
+    code: "DRIVING_LICENSE",
+    value: "Driving License",
+  }]);
+
+const partyIdentifierTypeID = mod.partyIdentifierType.select({
+  code: "PASSPORT",
+});
 
 const partyIdentifierInsertion = mod.partyIdentifier
   .insertDML({
     identifier_number: "test identifier",
-    party_identifier_type_id: "PASSPORT",
+    party_identifier_type_id: partyIdentifierTypeID,
     party_id: partyID,
   });
 
+const personTypeInsertion = mod.personType
+  .insertDML([{
+    code: "INDIVIDUAL",
+    value: "Individual",
+  }, {
+    code: "PROFESSIONAL",
+    value: "Professional",
+  }]);
+
+const personTypeID = mod.personType.select({
+  code: "PROFESSIONAL",
+});
 const personInsertion = mod.person
   .insertDML({
     party_id: partyID,
-    person_type_id: "PROFESSIONAL",
+    person_type_id: personTypeID,
     person_first_name: "Test First Name",
     person_last_name: "Test Last Name",
   });
+
+const partyRole = mod.partyRole
+  .insertDML([{
+    code: "VENDOR",
+    value: "Vendor",
+  }, {
+    code: "CUSTOMER",
+    value: "Customer",
+  }]);
+
+const partyRoleID = mod.partyRole.select({ code: "VENDOR" });
 
 const partyRelationInsertion = mod.partyRelation
   .insertDML({
     party_id: partyID,
     related_party_id: partyID,
     relation_type_id: "ORGANIZATION_TO_PERSON",
-    party_role_id: "VENDOR",
+    party_role_id: partyRoleID,
   });
 
 const organizationInsertion = mod.organization
@@ -87,9 +126,32 @@ const organizationRoleInsertion = mod.organizationRole
     organization_role_type_id: organizationRoleTypeCode,
   });
 
+const contactType = mod.contactType
+  .insertDML([{
+    code: "HOME_ADDRESS",
+    value: "Home Address",
+  }, {
+    code: "OFFICIAL_ADDRESS",
+    value: "Official Address",
+  }, {
+    code: "MOBILE_PHONE_NUMBER",
+    value: "Mobile Phone Number",
+  }, {
+    code: "LAND_PHONE_NUMBER",
+    value: "Land Phone Number",
+  }, {
+    code: "OFFICIAL_EMAIL",
+    value: "Official Email",
+  }, {
+    code: "PERSONAL_EMAIL",
+    value: "Personal Email",
+  }]);
+
+const contactTypeID = mod.contactType.select({ code: "MOBILE_PHONE_NUMBER" });
+
 const contactElectronicInsertion = mod.contactElectronic
   .insertDML({
-    contact_type_id: "MOBILE_PHONE_NUMBER",
+    contact_type_id: contactTypeID,
     party_id: partyID,
     electronics_details: "electronics details",
   });
@@ -100,7 +162,10 @@ function sqlDDL() {
 
     -- synthetic / test data
 
+    ${partyRole}
     ${partyInsertion}
+    ${personTypeInsertion}
+    ${partyIdentifierType}
 
     ${partyIdentifierInsertion}
 
@@ -114,6 +179,7 @@ function sqlDDL() {
 
     ${organizationRoleInsertion}
 
+    ${contactType}
     ${contactElectronicInsertion}
     `;
 }


### PR DESCRIPTION
The following pattern/udm/governance.ts enumerations  migrated to regular reference tables because their seed values as well as data rows will be different across UDM pattern consumers:

 - [x] PartyRole
 - [x] PartyIdentifierType
 - [x] ContactType
 - [x] any others whose values might be different in consumers