### PR TITLE
Create varchar primary key for sqlite db & islm migrate fixes

### DIFF
--- a/pattern/postgres/migrate.ts
+++ b/pattern/postgres/migrate.ts
@@ -287,9 +287,9 @@ export class PgMigrate<
       CASE task
       WHEN 'migrate' THEN
         FOR r IN (
-          SELECT sp_migration,sp_migration_undo,fn_migration_status FROM ${this.infoSchemaLifecycle.sqlNamespace}.${islmGovernance.tableName} WHERE from_state = '${TransitionStatus.NONE}' AND to_state = '${TransitionStatus.SQLLOADED}' AND (target_version_number NOT IN (SELECT version_number FROM ${this.infoSchemaLifecycle.sqlNamespace}.${islmGovernance.tableName} WHERE from_state = '${TransitionStatus.SQLLOADED}' AND to_state = '${TransitionStatus.MIGRATED}')) AND
-          (target_version_number IS NULL OR version_number<=target_version_number)
-          ORDER BY version
+          SELECT sp_migration,sp_migration_undo,fn_migration_status FROM ${this.infoSchemaLifecycle.sqlNamespace}.${islmGovernance.tableName} WHERE from_state = '${TransitionStatus.NONE}' AND to_state = '${TransitionStatus.SQLLOADED}' AND (target_version_number NOT IN (SELECT state_sort_index FROM ${this.infoSchemaLifecycle.sqlNamespace}.${islmGovernance.tableName} WHERE from_state = '${TransitionStatus.SQLLOADED}' AND to_state = '${TransitionStatus.MIGRATED}')) AND
+          (target_version_number IS NULL OR state_sort_index<=target_version_number)
+          ORDER BY state_sort_index
         ) LOOP
           -- Check if migration has been executed
           -- Construct procedure and status function names
@@ -323,7 +323,7 @@ export class PgMigrate<
           migrate_rb_insertion_sql TEXT;
           sp_migration_undo_sql TEXT;
         BEGIN
-          SELECT sp_migration_undo FROM ${this.infoSchemaLifecycle.sqlNamespace}.${islmGovernance.tableName} WHERE from_state = '${TransitionStatus.SQLLOADED}' AND to_state = '${TransitionStatus.MIGRATED}' AND (target_version_number NOT IN (SELECT version_number FROM ${this.infoSchemaLifecycle.sqlNamespace}.${islmGovernance.tableName} WHERE from_state = '${TransitionStatus.MIGRATED}' AND to_state = '${TransitionStatus.ROLLBACK}')) ORDER BY version INTO sp_migration_undo_sql;
+          SELECT sp_migration_undo FROM ${this.infoSchemaLifecycle.sqlNamespace}.${islmGovernance.tableName} WHERE from_state = '${TransitionStatus.SQLLOADED}' AND to_state = '${TransitionStatus.MIGRATED}' AND (target_version_number NOT IN (SELECT state_sort_index FROM ${this.infoSchemaLifecycle.sqlNamespace}.${islmGovernance.tableName} WHERE from_state = '${TransitionStatus.MIGRATED}' AND to_state = '${TransitionStatus.ROLLBACK}')) ORDER BY state_sort_index INTO sp_migration_undo_sql;
           IF sp_migration_undo_sql IS NOT NULL THEN
             EXECUTE format('CALL ${this.infoSchemaLifecycle.sqlNamespace}."%s"()', sp_migration_undo_sql);
 

--- a/pattern/postgres/migrate_test.fixture.sql
+++ b/pattern/postgres/migrate_test.fixture.sql
@@ -35,9 +35,9 @@ BEGIN
     CASE task
     WHEN 'migrate' THEN
       FOR r IN (
-        SELECT sp_migration,sp_migration_undo,fn_migration_status FROM info_schema_lifecycle.islm_governance WHERE from_state = 'None' AND to_state = 'SQL Loaded' AND (target_version_number NOT IN (SELECT version_number FROM info_schema_lifecycle.islm_governance WHERE from_state = 'SQL Loaded' AND to_state = 'Migrated')) AND
-        (target_version_number IS NULL OR version_number<=target_version_number)
-        ORDER BY version
+        SELECT sp_migration,sp_migration_undo,fn_migration_status FROM info_schema_lifecycle.islm_governance WHERE from_state = 'None' AND to_state = 'SQL Loaded' AND (target_version_number NOT IN (SELECT state_sort_index FROM info_schema_lifecycle.islm_governance WHERE from_state = 'SQL Loaded' AND to_state = 'Migrated')) AND
+        (target_version_number IS NULL OR state_sort_index<=target_version_number)
+        ORDER BY state_sort_index
       ) LOOP
         -- Check if migration has been executed
         -- Construct procedure and status function names
@@ -71,7 +71,7 @@ BEGIN
         migrate_rb_insertion_sql TEXT;
         sp_migration_undo_sql TEXT;
       BEGIN
-        SELECT sp_migration_undo FROM info_schema_lifecycle.islm_governance WHERE from_state = 'SQL Loaded' AND to_state = 'Migrated' AND (target_version_number NOT IN (SELECT version_number FROM info_schema_lifecycle.islm_governance WHERE from_state = 'Migrated' AND to_state = 'Rollback')) ORDER BY version INTO sp_migration_undo_sql;
+        SELECT sp_migration_undo FROM info_schema_lifecycle.islm_governance WHERE from_state = 'SQL Loaded' AND to_state = 'Migrated' AND (target_version_number NOT IN (SELECT state_sort_index FROM info_schema_lifecycle.islm_governance WHERE from_state = 'Migrated' AND to_state = 'Rollback')) ORDER BY state_sort_index INTO sp_migration_undo_sql;
         IF sp_migration_undo_sql IS NOT NULL THEN
           EXECUTE format('CALL info_schema_lifecycle."%s"()', sp_migration_undo_sql);
   

--- a/pattern/typical/typical.ts
+++ b/pattern/typical/typical.ts
@@ -53,18 +53,30 @@ export function governedDomains<
     text: z.string,
     textNullable: () => z.string().optional(),
 
-    varChar: (maxLength: number) =>
-      z.string(
-        SQLa.zodSqlDomainRawCreateParams(
-          SQLa.sqlDomainZodStringDescr({ isVarChar: true }),
+    varChar: (maxLength?: number) =>
+      maxLength
+        ? z.string(
+          SQLa.zodSqlDomainRawCreateParams(
+            SQLa.sqlDomainZodStringDescr({ isVarChar: true }),
+          ),
+        ).max(maxLength)
+        : z.string(
+          SQLa.zodSqlDomainRawCreateParams(
+            SQLa.sqlDomainZodStringDescr({ isVarChar: true }),
+          ),
         ),
-      ).max(maxLength),
-    varCharNullable: (maxLength: number) =>
-      z.string(
-        SQLa.zodSqlDomainRawCreateParams(
-          SQLa.sqlDomainZodStringDescr({ isVarChar: true }),
-        ),
-      ).max(maxLength).optional(),
+    varCharNullable: (maxLength?: number) =>
+      maxLength
+        ? z.string(
+          SQLa.zodSqlDomainRawCreateParams(
+            SQLa.sqlDomainZodStringDescr({ isVarChar: true }),
+          ),
+        ).max(maxLength).optional()
+        : z.string(
+          SQLa.zodSqlDomainRawCreateParams(
+            SQLa.sqlDomainZodStringDescr({ isVarChar: true }),
+          ),
+        ).optional(),
 
     integer: () => z.number().int(),
     integerNullable: () => z.number().int().optional(),
@@ -230,9 +242,10 @@ export function governedKeys<
   // in governedDomains as an argument because deep-generics type-safe objects
   // will be available through inference.
   const pkcf = SQLa.primaryKeyColumnFactory<Context, DomainQS>();
-  const { ulid } = governedDomains<DomainQS, DomainsQS, Context>();
+  const { ulid, varChar } = governedDomains<DomainQS, DomainsQS, Context>();
 
   const textPrimaryKey = () => pkcf.primaryKey(z.string());
+  const varcharPrimaryKey = () => pkcf.primaryKey(varChar());
   const ulidPrimaryKey = () => pkcf.primaryKey(ulid());
   const autoIncPrimaryKey = pkcf.autoIncPrimaryKey;
 
@@ -240,6 +253,7 @@ export function governedKeys<
     textPrimaryKey,
     ulidPrimaryKey,
     autoIncPrimaryKey,
+    varcharPrimaryKey,
   };
 }
 

--- a/render/domain/domain.ts
+++ b/render/domain/domain.ts
@@ -354,6 +354,9 @@ export function zodStringSqlDomainFactory<
             if (tmpl.isMsSqlServerDialect(ctx.sqlDialect)) {
               return `NVARCHAR(${maxLength ? maxLength : "MAX"})`;
             }
+            if (tmpl.isSqliteDialect(ctx.sqlDialect)) {
+              return `VARCHAR`;
+            }
             return `VARCHAR(${
               maxLength
                 ? maxLength


### PR DESCRIPTION
- Created a new varchar primary key for sqllite db and updated the test cases.
- Fixed the field names of the governance table in the ctrl procedure queries.