### PR TITLE
feat: uuid primary key for sqlite db

### DIFF
--- a/pattern/observability/mod_test.telem-sqlite-fixture.sql
+++ b/pattern/observability/mod_test.telem-sqlite-fixture.sql
@@ -1,6 +1,6 @@
 CREATE TABLE IF NOT EXISTS "span" (
     "span_id" INTEGER PRIMARY KEY AUTOINCREMENT,
-    "trace_id" TEXT NOT NULL,
+    "trace_id" UUID NOT NULL,
     "parent_span_id" INTEGER,
     "name" TEXT NOT NULL,
     "start_time" TIMESTAMP NOT NULL,

--- a/pattern/typical/typical.ts
+++ b/pattern/typical/typical.ts
@@ -196,7 +196,10 @@ export function governedDomains<
         SQLa.sqlDomainZodStringDescr({ isUlid: true }),
       )).ulid().optional(),
 
-    uuid: () => z.string().uuid(),
+    uuid: () =>
+      z.string(SQLa.zodSqlDomainRawCreateParams(
+        SQLa.sqlDomainZodStringDescr({ isUuid: true }),
+      )).uuid(),
     uuidNullable: () =>
       z.string(SQLa.zodSqlDomainRawCreateParams(
         SQLa.sqlDomainZodStringDescr({ isUuid: true }),
@@ -242,18 +245,24 @@ export function governedKeys<
   // in governedDomains as an argument because deep-generics type-safe objects
   // will be available through inference.
   const pkcf = SQLa.primaryKeyColumnFactory<Context, DomainQS>();
-  const { ulid, varChar } = governedDomains<DomainQS, DomainsQS, Context>();
+  const { ulid, varChar, uuid } = governedDomains<
+    DomainQS,
+    DomainsQS,
+    Context
+  >();
 
   const textPrimaryKey = () => pkcf.primaryKey(z.string());
-  const varcharPrimaryKey = () => pkcf.primaryKey(varChar());
+  const varCharPrimaryKey = () => pkcf.primaryKey(varChar());
   const ulidPrimaryKey = () => pkcf.primaryKey(ulid());
+  const uuidPrimaryKey = () => pkcf.primaryKey(uuid());
   const autoIncPrimaryKey = pkcf.autoIncPrimaryKey;
 
   return {
     textPrimaryKey,
     ulidPrimaryKey,
     autoIncPrimaryKey,
-    varcharPrimaryKey,
+    varCharPrimaryKey,
+    uuidPrimaryKey,
   };
 }
 

--- a/pattern/typical/typical_test.ts
+++ b/pattern/typical/typical_test.ts
@@ -35,7 +35,7 @@ export function syntheticSchema<Context extends SQLa.SqlEmitContext>(
   });
 
   const publAnotherHost = gm.textPkTable("publ_another_host", {
-    publ_another_host_id: keys.varcharPrimaryKey(),
+    publ_another_host_id: keys.varCharPrimaryKey(),
     host: tcf.unique(sd.text()),
     host_identity: sd.jsonTextNullable(),
     host_type_code: hostType.references.code(),

--- a/render/domain/domain.ts
+++ b/render/domain/domain.ts
@@ -432,8 +432,8 @@ export function zodStringSqlDomainFactory<
       return {
         ...ztaSDF.defaults<Identity>(zodType, init),
         sqlDataType: () => ({
-          SQL: (_ctx: Context) => {
-            return `TEXT`;
+          SQL: (ctx: Context) => {
+            return tmpl.isSqliteDialect(ctx.sqlDialect) ? "UUID" : "TEXT";
           },
         }),
         sqlDefaultValue: () => ({


### PR DESCRIPTION
- Created  uuid primary key for sqllite db
- Fixed naming convention for varchar primary key.