### PR TITLE
Implicit cast to varchar in SQL query for latest release of duckdb

### DIFF
--- a/pattern/orchestration/duckdb/assurance.ts
+++ b/pattern/orchestration/duckdb/assurance.ts
@@ -175,7 +175,7 @@ export function typicalValueAssuranceRules<Context extends SQLa.SqlEmitContext>(
                  src_file_row_number AS issue_row
             FROM "${tableName}"
            WHERE "${columnName}" IS NULL
-              OR TRIM("${columnName}") = ''
+              OR TRIM(CAST("${columnName}" AS VARCHAR)) = ''
       )
       ${govn.insertRowValueIssueCtePartial(cteName,
         'Missing Mandatory Value',

--- a/pattern/orchestration/duckdb/assurance_test-fixture.duckdb.sql
+++ b/pattern/orchestration/duckdb/assurance_test-fixture.duckdb.sql
@@ -124,7 +124,7 @@ WITH mandatory_value AS (
            src_file_row_number AS issue_row
       FROM "synthetic_csv_fail"
      WHERE "column7" IS NULL
-        OR TRIM("column7") = ''
+        OR TRIM(CAST("column7" AS VARCHAR)) = ''
 )
 INSERT INTO ingest_issue (session_id, issue_type, issue_row, issue_column, invalid_value, issue_message, remediation)
     SELECT (SELECT orch_session_id FROM orch_session LIMIT 1),

--- a/pattern/typical/typical_test.ts
+++ b/pattern/typical/typical_test.ts
@@ -141,6 +141,7 @@ export function syntheticSchema<Context extends SQLa.SqlEmitContext>(
 }
 
 Deno.test("SQL Aide (SQLa) emit template", () => {
+  // deno-lint-ignore no-empty-interface
   interface SyntheticTmplContext extends SQLa.SqlEmitContext {
   }
   const stContext = (): SyntheticTmplContext => SQLa.typicalSqlEmitContext();

--- a/render/dialect/pg/routine.ts
+++ b/render/dialect/pg/routine.ts
@@ -454,6 +454,7 @@ export interface StoredRoutineDefnOptions<
   readonly sqlNS?: tmpl.SqlNamespaceSupplier;
 }
 
+// deno-lint-ignore no-empty-interface
 export interface StoredProcedureDefnOptions<
   RoutineName extends string,
   Context extends tmpl.SqlEmitContext,


### PR DESCRIPTION
- Updated the SQL query with implicit casting to varchar for the latest duckdb release 0.10.2.